### PR TITLE
Adds three new language manuals that can be ordered via cargo.

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2567,6 +2567,39 @@
 					/obj/item/book/random)
 	crate_type = /obj/structure/closet/crate/wooden
 
+/datum/supply_pack/misc/language_manuals/sylvan
+	name = "Language Manuals (Sylvan)"
+	desc = "A five pack of language manuals for learning the plant language Sylvan."
+	cost = CARGO_CRATE_VALUE * 15
+	contains = list(/obj/item/language_manual/sylvan,
+					/obj/item/language_manual/sylvan,
+					/obj/item/language_manual/sylvan,
+					/obj/item/language_manual/sylvan,
+					/obj/item/language_manual/sylvan)
+	crate_type = /obj/structure/closet/crate/wooden
+
+/datum/supply_pack/misc/language_manuals/draconic
+	name = "Language Manuals (Draconic)"
+	desc = "A five pack of language manuals for learning the ashwalker language Draconic."
+	cost = CARGO_CRATE_VALUE * 15
+	contains = list(/obj/item/language_manual/draconic,
+					/obj/item/language_manual/draconic,
+					/obj/item/language_manual/draconic,
+					/obj/item/language_manual/draconic,
+					/obj/item/language_manual/draconic)
+	crate_type = /obj/structure/closet/crate/wooden
+
+/datum/supply_pack/misc/language_manuals/terrum
+	name = "Language Manuals (Terrum)"
+	desc = "A five pack of language manuals for learning the golem language Terrum."
+	cost = CARGO_CRATE_VALUE * 15
+	contains = list(/obj/item/language_manual/terrum,
+					/obj/item/language_manual/terrum,
+					/obj/item/language_manual/terrum,
+					/obj/item/language_manual/terrum,
+					/obj/item/language_manual/terrum)
+	crate_type = /obj/structure/closet/crate/wooden
+
 /datum/supply_pack/misc/exploration_drone
 	name = "Exploration Drone"
 	desc = "A replacement long-range exploration drone."

--- a/code/modules/language/language_manuals.dm
+++ b/code/modules/language/language_manuals.dm
@@ -74,3 +74,22 @@
 		return
 
 	return ..()
+
+//language manuals for "natural" (ghostrole and niche non-antag) languages
+/obj/item/language_manual/sylvan
+	name = "sylvan language manual"
+	desc = "The book's cover reads: \"Sylvan Wanderings - Learn how a plant thinks, feels and speaks!\""
+	language = /datum/language/sylvan
+	flavour_text = "you suddenly feel a lot more in tune with nature"
+
+/obj/item/language_manual/draconic
+	name = "draconic language manual"
+	desc = "The book's cover reads: \"Tipping the Scales - Learn how to survive, thrive and communicate on one of the galaxy's deadliest planets!\""
+	language = /datum/language/draconic
+	flavour_text = "you suddenly feel like a Lavaland native"
+
+/obj/item/language_manual/terrum
+	name = "terrum language manual"
+	desc = "The book's cover reads: \"Mind Like a Stone - Dr. Emmet Bukowski\""
+	language = /datum/language/terrum
+	flavour_text = "suddenly your grasp of golem speech becomes rock solid"

--- a/code/modules/language/language_manuals.dm
+++ b/code/modules/language/language_manuals.dm
@@ -80,13 +80,13 @@
 	name = "sylvan language manual"
 	desc = "The book's cover reads: \"Sylvan Wanderings - Learn how a plant thinks, feels and speaks!\""
 	language = /datum/language/sylvan
-	flavour_text = "you suddenly feel a lot more in tune with nature"
+	flavour_text = "suddenly you feel a lot more in tune with nature"
 
 /obj/item/language_manual/draconic
 	name = "draconic language manual"
 	desc = "The book's cover reads: \"Tipping the Scales - Learn how to survive, thrive and communicate on one of the galaxy's deadliest planets!\""
 	language = /datum/language/draconic
-	flavour_text = "you suddenly feel like a Lavaland native"
+	flavour_text = "suddenly you feel like a Lavaland native"
 
 /obj/item/language_manual/terrum
 	name = "terrum language manual"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds language manuals for Sylvan, Terrum and Draconic orderable in packs of five for 3000 credits.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's a non-RNG reliant way to engage with the situational presence of non-galcom speaking roles.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added language manuals for learning Sylvan, Terrum and Draconic.
add: Added crates containing five of a kind of the new language manuals, available from cargo for 3000 credits apiece.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
