### PR TITLE
Language manuals disintegrate when all charges are used instead of morphing into another manual (except codespeak).

### DIFF
--- a/code/modules/language/language_manuals.dm
+++ b/code/modules/language/language_manuals.dm
@@ -41,7 +41,7 @@
 
 /obj/item/language_manual/proc/use_charge(mob/user)
 	charges--
-	if(!charges)
+	if(charges <= 0)
 		var/turf/T = get_turf(src)
 		T.visible_message(span_warning("The [src] disintegrates, blasted cheap paper!"))
 
@@ -56,7 +56,7 @@
 
 /obj/item/language_manual/codespeak_manual/use_charge(mob/user)
 	charges--
-	if(!charges)
+	if(charges <= 0)
 		var/turf/T = get_turf(src)
 		T.visible_message(span_warning("The cover and contents of [src] start shifting and changing!"))
 

--- a/code/modules/language/language_manuals.dm
+++ b/code/modules/language/language_manuals.dm
@@ -43,17 +43,26 @@
 	charges--
 	if(!charges)
 		var/turf/T = get_turf(src)
-		T.visible_message(span_warning("The cover and contents of [src] start shifting and changing!"))
+		T.visible_message(span_warning("The [src] disintegrates, blasted cheap paper!"))
 
 		qdel(src)
-		var/obj/item/book/manual/random/book = new(T)
-		user.put_in_active_hand(book)
+		new /obj/effect/decal/cleanable/shreds(T)
 
 /obj/item/language_manual/codespeak_manual
 	name = "codespeak manual"
 	desc = "The book's cover reads: \"Codespeak(tm) - Secure your communication with metaphors so elaborate, they seem randomly generated!\""
 	language = /datum/language/codespeak
 	flavour_text = "suddenly your mind is filled with codewords and responses"
+
+/obj/item/language_manual/codespeak_manual/use_charge(mob/user)
+	charges--
+	if(!charges)
+		var/turf/T = get_turf(src)
+		T.visible_message(span_warning("The cover and contents of [src] start shifting and changing!"))
+
+		qdel(src)
+		var/obj/item/book/manual/random/book = new(T)
+		user.put_in_active_hand(book)
 
 /obj/item/language_manual/codespeak_manual/unlimited
 	name = "deluxe codespeak manual"

--- a/code/modules/language/language_manuals.dm
+++ b/code/modules/language/language_manuals.dm
@@ -46,7 +46,7 @@
 		T.visible_message(span_warning("The [src] disintegrates, blasted cheap paper!"))
 
 		qdel(src)
-		new /obj/effect/decal/cleanable/shreds(T)
+		new /obj/effect/decal/cleanable/ash(T)
 
 /obj/item/language_manual/codespeak_manual
 	name = "codespeak manual"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Makes the language manuals that are not codespeak disintegrate rather than morph.

## Why It's Good For The Game

Purely thematic change as it's a bit strange for "normal" texts to magically transform and makes more sense for codespeak in a spy movie kind of way.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Language manuals other than codespeak now disintegrate rather than morph.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
