### PR TITLE
Removes cyborg stunarms and nerfs the damage of some of their tools.

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -4,34 +4,6 @@
 /obj/item/borg
 	icon = 'icons/mob/robot_items.dmi'
 
-
-/obj/item/borg/stun
-	name = "electrically-charged arm"
-	icon_state = "elecarm"
-	var/charge_cost = 30
-
-/obj/item/borg/stun/attack(mob/living/M, mob/living/user)
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		if(H.check_shields(src, 0, "[M]'s [name]", MELEE_ATTACK))
-			playsound(M, 'sound/weapons/genhit.ogg', 50, TRUE)
-			return FALSE
-	if(iscyborg(user))
-		var/mob/living/silicon/robot/R = user
-		if(!R.cell.use(charge_cost))
-			return
-
-	user.do_attack_animation(M)
-	M.Paralyze(100)
-	M.apply_effect(EFFECT_STUTTER, 5)
-
-	M.visible_message(span_danger("[user] prods [M] with [src]!"), \
-					span_userdanger("[user] prods you with [src]!"))
-
-	playsound(loc, 'sound/weapons/egloves.ogg', 50, TRUE, -1)
-
-	log_combat(user, M, "stunned", src, "(ISTATE: [user.istate.logging()])")
-
 /obj/item/borg/cyborghug
 	name = "hugging module"
 	icon_state = "hugmodule"

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -323,11 +323,29 @@
 	icon_state = "indwelder_cyborg"
 	toolspeed = 0.5
 
+/obj/item/weldingtool/largetank/cyborg/switched_on(mob/user)
+	set_welding(!welding)
+	if(welding)
+		if(get_fuel() >= 1)
+			to_chat(user, span_notice("You switch [src] on."))
+			playsound(loc, acti_sound, 50, TRUE)
+			force = 10
+			damtype = BURN
+			hitsound = 'sound/items/welder.ogg'
+			update_appearance()
+			START_PROCESSING(SSobj, src)
+		else
+			to_chat(user, span_warning("You need more fuel!"))
+			switched_off(user)
+	else
+		to_chat(user, span_notice("You switch [src] off."))
+		playsound(loc, deac_sound, 50, TRUE)
+		switched_off(user)
+
 /obj/item/weldingtool/largetank/cyborg/cyborg_unequip(mob/user)
 	if(!isOn())
 		return
 	switched_on(user)
-
 
 /obj/item/weldingtool/mini
 	name = "emergency welding tool"

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -348,7 +348,7 @@
 		/obj/item/cautery,
 		/obj/item/surgicaldrill,
 		/obj/item/scalpel,
-		/obj/item/circular_saw,
+		/obj/item/circular_saw/cyborg,
 		/obj/item/extinguisher/mini,
 		/obj/item/roller/robo,
 		/obj/item/borg/cyborghug/medical,

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -278,7 +278,6 @@
 		/obj/item/stack/tile/iron/base/cyborg,
 		/obj/item/stack/cable_coil)
 	radio_channels = list(RADIO_CHANNEL_ENGINEERING)
-	emag_modules = list(/obj/item/borg/stun)
 	cyborg_base_icon = "engineer"
 	model_select_icon = "engineer"
 	magpulsing = TRUE
@@ -380,7 +379,6 @@
 		/obj/item/gps/cyborg,
 		/obj/item/stack/marker_beacon)
 	radio_channels = list(RADIO_CHANNEL_SCIENCE, RADIO_CHANNEL_SUPPLY)
-	emag_modules = list(/obj/item/borg/stun)
 	cyborg_base_icon = "miner"
 	model_select_icon = "miner"
 	hat_offset = 0

--- a/code/modules/surgery/organs/cybernetics/augments_arms.dm
+++ b/code/modules/surgery/organs/cybernetics/augments_arms.dm
@@ -269,17 +269,11 @@
 	active_item.set_light_on(FALSE)
 	return ..()
 
-/obj/item/organ/cyberimp/arm/item_set/baton
-	name = "arm electrification implant"
-	desc = "An illegal combat implant that allows the user to administer disabling shocks from their arm."
-	encode_info = AUGMENT_TG_LEVEL
-	contents = newlist(/obj/item/borg/stun)
-
 /obj/item/organ/cyberimp/arm/item_set/combat
 	name = "combat cybernetics implant"
 	desc = "A powerful cybernetic implant that contains combat modules built into the user's arm."
 	encode_info = AUGMENT_TG_LEVEL
-	contents = newlist(/obj/item/melee/transforming/energy/blade/hardlight, /obj/item/gun/medbeam, /obj/item/borg/stun, /obj/item/assembly/flash/armimplant)
+	contents = newlist(/obj/item/melee/transforming/energy/blade/hardlight, /obj/item/gun/medbeam, /obj/item/assembly/flash/armimplant)
 
 /obj/item/organ/cyberimp/arm/item_set/combat/Initialize()
 	. = ..()

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -127,6 +127,8 @@
 	w_class = WEIGHT_CLASS_SMALL
 	toolspeed = 0.5
 
+/obj/item/surgicaldrill/cyborg
+	force = 10
 
 /obj/item/scalpel
 	name = "scalpel"

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -197,6 +197,8 @@
 	w_class = WEIGHT_CLASS_SMALL
 	toolspeed = 0.5
 
+/obj/item/circular_saw/cyborg
+	force = 10
 
 /obj/item/surgical_drapes
 	name = "surgical drapes"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the cyborg stunarm from borgs and also removes the implant that grants it to humanoids.

Nerfs the damage of lit cyborg welding tools, circular saws and surgical drills from 15 to 10.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Emagged and malfunctioning cyborgs have it way too easy. Hopefully these changes will force them to vary up their tactics, work together and not unga-bunga so much.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Cyborg stunarms have been removed.
del: The cybernetic implants utilising the stunarm have been removed and changed respectively.
balance: The damage of cyborg welding torches (when lit), circular saws and surgical drills has been reduced from 15 to 10.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
