### PR TITLE
Adds defines that determine the processing speed of food items (and defaults this time to 0.1 seconds).

### DIFF
--- a/code/__DEFINES/cooking.dm
+++ b/code/__DEFINES/cooking.dm
@@ -1,0 +1,13 @@
+//integers here represent time in deciseconds, used in food code to determine the length of time it takes to process a given type of food with a tool (knife, rolling pin, etc.)
+#define TIME_TO_PROCESS_BREAD 1
+#define TIME_TO_PROCESS_CAKE 1
+#define TIME_TO_PROCESS_DOUGH 1
+#define TIME_TO_PROCESS_MEAT 1
+#define TIME_TO_PROCESS_CHEESE 1
+#define TIME_TO_PROCESS_PIE 1
+#define TIME_TO_PROCESS_PIZZA 1
+#define TIME_TO_PROCESS_FISH 1
+#define TIME_TO_PROCESS_FRUIT 1
+#define TIME_TO_PROCESS_VEGETABLE 1
+
+//all currently set to 1 to make processing near-instantaneous

--- a/code/game/objects/items/food/bread.dm
+++ b/code/game/objects/items/food/bread.dm
@@ -37,7 +37,7 @@
 	AddComponent(/datum/component/customizable_reagent_holder, /obj/item/food/bread/empty, CUSTOM_INGREDIENT_ICON_FILL, max_ingredients = 8)
 
 /obj/item/food/bread/plain/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/breadslice/plain, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/breadslice/plain, 5, TIME_TO_PROCESS_BREAD)
 
 /obj/item/food/breadslice/plain
 	name = "bread slice"
@@ -75,7 +75,7 @@
 
 
 /obj/item/food/bread/meat/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/breadslice/meat, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/breadslice/meat, 5, TIME_TO_PROCESS_BREAD)
 
 /obj/item/food/breadslice/meat
 	name = "meatbread slice"
@@ -93,7 +93,7 @@
 	foodtypes = GRAIN | MEAT
 
 /obj/item/food/bread/xenomeat/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/breadslice/xenomeat, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/breadslice/xenomeat, 5, TIME_TO_PROCESS_BREAD)
 
 /obj/item/food/breadslice/xenomeat
 	name = "xenomeatbread slice"
@@ -111,7 +111,7 @@
 	foodtypes = GRAIN | MEAT | TOXIC
 
 /obj/item/food/bread/spidermeat/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/breadslice/spidermeat, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/breadslice/spidermeat, 5, TIME_TO_PROCESS_BREAD)
 
 /obj/item/food/breadslice/spidermeat
 	name = "spider meat bread slice"
@@ -129,7 +129,7 @@
 	foodtypes = GRAIN | FRUIT
 
 /obj/item/food/bread/banana/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/breadslice/banana, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/breadslice/banana, 5, TIME_TO_PROCESS_BREAD)
 
 /obj/item/food/breadslice/banana
 	name = "banana-nut bread slice"
@@ -148,7 +148,7 @@
 	venue_value = FOOD_PRICE_TRASH
 
 /obj/item/food/bread/tofu/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/breadslice/tofu, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/breadslice/tofu, 5, TIME_TO_PROCESS_BREAD)
 
 /obj/item/food/breadslice/tofu
 	name = "tofubread slice"
@@ -166,7 +166,7 @@
 	foodtypes = GRAIN | DAIRY
 
 /obj/item/food/bread/creamcheese/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/breadslice/creamcheese, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/breadslice/creamcheese, 5, TIME_TO_PROCESS_BREAD)
 
 /obj/item/food/breadslice/creamcheese
 	name = "cream cheese bread slice"
@@ -180,7 +180,7 @@
 	desc = "It's bread, customized to your wildest dreams."
 
 /obj/item/food/bread/empty/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/breadslice/empty, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/breadslice/empty, 5, TIME_TO_PROCESS_BREAD)
 
 /obj/item/food/bread/mimana
 	name = "mimana bread"
@@ -191,7 +191,7 @@
 	foodtypes = GRAIN | FRUIT
 
 /obj/item/food/bread/mimana/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/breadslice/mimana, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/breadslice/mimana, 5, TIME_TO_PROCESS_BREAD)
 
 /obj/item/food/breadslice/mimana
 	name = "mimana bread slice"

--- a/code/game/objects/items/food/cake.dm
+++ b/code/game/objects/items/food/cake.dm
@@ -26,7 +26,7 @@
 	foodtypes = GRAIN | DAIRY | SUGAR
 
 /obj/item/food/cake/plain/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/plain, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/plain, 5, TIME_TO_PROCESS_CAKE)
 
 /obj/item/food/cakeslice/plain
 	name = "plain cake slice"
@@ -46,7 +46,7 @@
 
 
 /obj/item/food/cake/carrot/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/carrot, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/carrot, 5, TIME_TO_PROCESS_CAKE)
 
 /obj/item/food/cakeslice/carrot
 	name = "carrot cake slice"
@@ -65,7 +65,7 @@
 	foodtypes = GRAIN | DAIRY | MEAT | GROSS | SUGAR
 
 /obj/item/food/cake/brain/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/brain, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/brain, 5, TIME_TO_PROCESS_CAKE)
 
 /obj/item/food/cakeslice/brain
 	name = "brain cake slice"
@@ -86,7 +86,7 @@
 
 
 /obj/item/food/cake/cheese/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/cheese, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/cheese, 5, TIME_TO_PROCESS_CAKE)
 
 /obj/item/food/cakeslice/cheese
 	name = "cheese cake slice"
@@ -106,7 +106,7 @@
 	venue_value = FOOD_PRICE_CHEAP
 
 /obj/item/food/cake/orange/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/orange, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/orange, 5, TIME_TO_PROCESS_CAKE)
 
 /obj/item/food/cakeslice/orange
 	name = "orange cake slice"
@@ -125,7 +125,7 @@
 	venue_value = FOOD_PRICE_CHEAP
 
 /obj/item/food/cake/lime/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/lime, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/lime, 5, TIME_TO_PROCESS_CAKE)
 
 /obj/item/food/cakeslice/lime
 	name = "lime cake slice"
@@ -144,7 +144,7 @@
 	venue_value = FOOD_PRICE_CHEAP
 
 /obj/item/food/cake/lemon/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/lemon, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/lemon, 5, TIME_TO_PROCESS_CAKE)
 
 /obj/item/food/cakeslice/lemon
 	name = "lemon cake slice"
@@ -163,7 +163,7 @@
 	venue_value = FOOD_PRICE_CHEAP
 
 /obj/item/food/cake/chocolate/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/chocolate, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/chocolate, 5, TIME_TO_PROCESS_CAKE)
 
 /obj/item/food/cakeslice/chocolate
 	name = "chocolate cake slice"
@@ -181,7 +181,7 @@
 	foodtypes = GRAIN | DAIRY | JUNKFOOD | SUGAR
 
 /obj/item/food/cake/birthday/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/birthday, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/birthday, 5, TIME_TO_PROCESS_CAKE)
 
 /obj/item/food/cake/birthday/microwave_act(obj/machinery/microwave/M) //super sekrit club
 	new /obj/item/clothing/head/hardhat/cakehat(get_turf(src))
@@ -205,7 +205,7 @@
 	tastes = list("cake" = 3, "a Vlad's Salad" = 1)
 
 /obj/item/food/cake/birthday/energy/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/birthday/energy, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/birthday/energy, 5, TIME_TO_PROCESS_CAKE)
 
 /obj/item/food/cake/birthday/energy/proc/energy_bite(mob/living/user)
 	to_chat(user, "<font color='red' size='5'>As you eat the cake, you accidentally hurt yourself on the embedded energy sword!</font>")
@@ -253,7 +253,7 @@
 	venue_value = FOOD_PRICE_CHEAP
 
 /obj/item/food/cake/apple/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/apple, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/apple, 5, TIME_TO_PROCESS_CAKE)
 
 /obj/item/food/cakeslice/apple
 	name = "apple cake slice"
@@ -271,7 +271,7 @@
 	foodtypes = GRAIN | DAIRY | SUGAR
 
 /obj/item/food/cake/slimecake/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/slimecake, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/slimecake, 5, TIME_TO_PROCESS_CAKE)
 
 /obj/item/food/cakeslice/slimecake
 	name = "slime cake slice"
@@ -290,7 +290,7 @@
 	venue_value = FOOD_PRICE_CHEAP
 
 /obj/item/food/cake/pumpkinspice/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/pumpkinspice, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/pumpkinspice, 5, TIME_TO_PROCESS_CAKE)
 
 /obj/item/food/cakeslice/pumpkinspice
 	name = "pumpkin spice cake slice"
@@ -308,7 +308,7 @@
 	foodtypes = GRAIN | DAIRY | FRUIT | SUGAR
 
 /obj/item/food/cake/bsvc/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/bsvc, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/bsvc, 5, TIME_TO_PROCESS_CAKE)
 
 /obj/item/food/cakeslice/bsvc
 	name = "blackberry and strawberry vanilla cake slice"
@@ -326,7 +326,7 @@
 	foodtypes = GRAIN | DAIRY | FRUIT | SUGAR
 
 /obj/item/food/cake/bscc/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/bscc, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/bscc, 5, TIME_TO_PROCESS_CAKE)
 
 /obj/item/food/cakeslice/bscc
 	name = "strawberry chocolate cake slice"
@@ -344,7 +344,7 @@
 	foodtypes = GRAIN | DAIRY | SUGAR
 
 /obj/item/food/cake/holy_cake/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/holy_cake_slice, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/holy_cake_slice, 5, TIME_TO_PROCESS_CAKE)
 
 /obj/item/food/cakeslice/holy_cake_slice
 	name = "angel food cake slice"
@@ -363,7 +363,7 @@
 	venue_value = FOOD_PRICE_CHEAP
 
 /obj/item/food/cake/pound_cake/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/pound_cake_slice, 7, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/pound_cake_slice, 7, TIME_TO_PROCESS_CAKE)
 
 /obj/item/food/cakeslice/pound_cake_slice
 	name = "pound cake slice"
@@ -382,7 +382,7 @@
 	foodtypes = GRAIN | GROSS
 
 /obj/item/food/cake/hardware_cake/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/hardware_cake_slice, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/hardware_cake_slice, 5, TIME_TO_PROCESS_CAKE)
 
 /obj/item/food/cakeslice/hardware_cake_slice
 	name = "hardware cake slice"
@@ -401,7 +401,7 @@
 	foodtypes = GRAIN | SUGAR | DAIRY
 
 /obj/item/food/cake/vanilla_cake/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/vanilla_slice, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/vanilla_slice, 5, TIME_TO_PROCESS_CAKE)
 
 /obj/item/food/cakeslice/vanilla_slice
 	name = "vanilla cake slice"
@@ -420,7 +420,7 @@
 	foodtypes = GRAIN | SUGAR | DAIRY
 
 /obj/item/food/cake/clown_cake/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/clown_slice, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/clown_slice, 5, TIME_TO_PROCESS_CAKE)
 
 /obj/item/food/cakeslice/clown_slice
 	name = "clown cake slice"
@@ -439,7 +439,7 @@
 	foodtypes = GRAIN | DAIRY | FRUIT | SUGAR
 
 /obj/item/food/cake/trumpet/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/trumpet, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/trumpet, 5, TIME_TO_PROCESS_CAKE)
 
 /obj/item/food/cakeslice/trumpet
 	name = "spaceman's cake"
@@ -458,7 +458,7 @@
 	foodtypes = GRAIN | DAIRY | SUGAR
 
 /obj/item/food/cake/brioche/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/brioche, 6, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/brioche, 6, TIME_TO_PROCESS_CAKE)
 
 /obj/item/food/cakeslice/brioche
 	name = "brioche cake slice"
@@ -477,7 +477,7 @@
 	foodtypes = DAIRY | FRUIT | SUGAR
 
 /obj/item/food/cake/pavlovacream/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/pavlovacream, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/pavlovacream, 5, TIME_TO_PROCESS_CAKE)
 
 /obj/item/food/cakeslice/pavlovacream
 	name = "Pavlova slice"
@@ -495,7 +495,7 @@
 	foodtypes = NUTS | FRUIT | SUGAR
 
 /obj/item/food/cake/pavlovakorta/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/pavlovakorta, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/pavlovakorta, 5, TIME_TO_PROCESS_CAKE)
 
 /obj/item/food/cakeslice/pavlovakorta
 	name = "pavlova slice"

--- a/code/game/objects/items/food/dough.dm
+++ b/code/game/objects/items/food/dough.dm
@@ -15,7 +15,7 @@
 
 // Dough + rolling pin = flat dough
 /obj/item/food/dough/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_ROLLINGPIN, /obj/item/food/flatdough, 1, 30)
+	AddElement(/datum/element/processable, TOOL_ROLLINGPIN, /obj/item/food/flatdough, 1, TIME_TO_PROCESS_DOUGH)
 
 /obj/item/food/flatdough
 	name = "flat dough"
@@ -29,7 +29,7 @@
 
 // sliceable into 3xdoughslices
 /obj/item/food/flatdough/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/doughslice, 3, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/doughslice, 3, TIME_TO_PROCESS_DOUGH)
 
 /obj/item/food/pizzabread
 	name = "pizza bread"
@@ -81,7 +81,7 @@
 	foodtypes = GRAIN | DAIRY
 
 /obj/item/food/cakebatter/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_ROLLINGPIN, /obj/item/food/piedough, 1, 30)
+	AddElement(/datum/element/processable, TOOL_ROLLINGPIN, /obj/item/food/piedough, 1, TIME_TO_PROCESS_CAKE) //potential skub alert!
 
 /obj/item/food/piedough
 	name = "pie dough"
@@ -94,7 +94,7 @@
 	foodtypes = GRAIN | DAIRY
 
 /obj/item/food/piedough/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/rawpastrybase, 3, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/rawpastrybase, 3, TIME_TO_PROCESS_DOUGH)
 
 /obj/item/food/rawpastrybase
 	name = "raw pastry base"

--- a/code/game/objects/items/food/lizard.dm
+++ b/code/game/objects/items/food/lizard.dm
@@ -51,7 +51,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/headcheese/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/headcheese_slice, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/headcheese_slice, 5, TIME_TO_PROCESS_CHEESE)
 
 /obj/item/food/headcheese_slice
 	name = "headcheese slice"
@@ -292,7 +292,7 @@
 	foodtypes = VEGETABLES | NUTS
 
 /obj/item/food/rootdough/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_ROLLINGPIN, /obj/item/food/flatrootdough, 1, 30)
+	AddElement(/datum/element/processable, TOOL_ROLLINGPIN, /obj/item/food/flatrootdough, 1, TIME_TO_PROCESS_DOUGH)
 
 /obj/item/food/flatrootdough
 	name = "flat rootdough"
@@ -305,7 +305,7 @@
 	foodtypes = VEGETABLES | NUTS
 
 /obj/item/food/flatrootdough/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/rootdoughslice, 3, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/rootdoughslice, 3, TIME_TO_PROCESS_DOUGH)
 
 /obj/item/food/flatrootdough/MakeGrillable()
 	AddComponent(/datum/component/grillable, /obj/item/food/root_flatbread, rand(25 SECONDS, 35 SECONDS), TRUE, TRUE)
@@ -322,7 +322,7 @@
 	foodtypes = VEGETABLES | NUTS
 
 /obj/item/food/rootdoughslice/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/spaghetti/nizaya, 1, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/spaghetti/nizaya, 1, TIME_TO_PROCESS_DOUGH)
 
 /obj/item/food/root_flatbread
 	name = "root flatbread"
@@ -362,7 +362,7 @@
 	AddComponent(/datum/component/customizable_reagent_holder, /obj/item/food/bread/empty, CUSTOM_INGREDIENT_ICON_FILL, max_ingredients = 8)
 
 /obj/item/food/bread/root/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/breadslice/root, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/breadslice/root, 5, TIME_TO_PROCESS_BREAD)
 
 /obj/item/food/breadslice/root
 	name = "rootbread slice"
@@ -512,7 +512,7 @@
 	foodtypes = NUTS | SUGAR
 
 /obj/item/food/cake/korta_brittle/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/korta_brittle, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/korta_brittle, 5, TIME_TO_PROCESS_CAKE)
 
 /obj/item/food/cakeslice/korta_brittle
 	name = "korta brittle slice"

--- a/code/game/objects/items/food/meat.dm
+++ b/code/game/objects/items/food/meat.dm
@@ -158,7 +158,7 @@
 	AddComponent(/datum/component/grillable, meatball_type, rand(30 SECONDS, 40 SECONDS), TRUE)
 
 /obj/item/food/raw_meatball/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_ROLLINGPIN, patty_type, 1, 20)
+	AddElement(/datum/element/processable, TOOL_ROLLINGPIN, patty_type, 1, TIME_TO_PROCESS_MEAT)
 /obj/item/food/raw_meatball/human
 	name = "strange raw meatball"
 	meatball_type = /obj/item/food/meatball/human
@@ -309,8 +309,8 @@
 	venue_value = FOOD_PRICE_CHEAP
 
 /obj/item/food/sausage/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/salami, 6, 30)
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/american_sausage, 1, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/salami, 6, TIME_TO_PROCESS_MEAT)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/american_sausage, 1, TIME_TO_PROCESS_MEAT)
 
 /obj/item/food/american_sausage
 	name = "american sausage"
@@ -624,7 +624,7 @@
 	AddComponent(/datum/component/grillable, /obj/item/food/meat/steak/plain, rand(30 SECONDS, 90 SECONDS), TRUE, TRUE) //Add medium rare later maybe?
 
 /obj/item/food/meat/slab/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE,  /obj/item/food/meat/rawcutlet/plain, 3, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE,  /obj/item/food/meat/rawcutlet/plain, 3, TIME_TO_PROCESS_MEAT)
 
 ///////////////////////////////////// HUMAN MEATS //////////////////////////////////////////////////////
 
@@ -637,7 +637,7 @@
 	AddComponent(/datum/component/grillable, /obj/item/food/meat/steak/plain/human, rand(30 SECONDS, 90 SECONDS), TRUE, TRUE) //Add medium rare later maybe?
 
 /obj/item/food/meat/slab/human/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE,  /obj/item/food/meat/rawcutlet/plain/human, 3, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE,  /obj/item/food/meat/rawcutlet/plain/human, 3, TIME_TO_PROCESS_MEAT)
 
 /obj/item/food/meat/slab/pig
 	name = "pig meat"
@@ -783,7 +783,7 @@
 	AddComponent(/datum/component/grillable, /obj/item/food/meat/steak/killertomato, rand(70 SECONDS, 85 SECONDS), TRUE, TRUE)
 
 /obj/item/food/meat/slab/killertomato/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/meat/rawcutlet/killertomato, 3, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/meat/rawcutlet/killertomato, 3, TIME_TO_PROCESS_MEAT)
 
 /obj/item/food/meat/slab/bear
 	name = "bear meat"
@@ -794,7 +794,7 @@
 	foodtypes = RAW | MEAT
 
 /obj/item/food/meat/slab/bear/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/meat/rawcutlet/bear, 3, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/meat/rawcutlet/bear, 3, TIME_TO_PROCESS_MEAT)
 
 /obj/item/food/meat/slab/bear/MakeGrillable()
 	AddComponent(/datum/component/grillable, /obj/item/food/meat/steak/bear, rand(40 SECONDS, 70 SECONDS), TRUE, TRUE)
@@ -813,7 +813,7 @@
 	foodtypes = RAW | MEAT
 
 /obj/item/food/meat/slab/xeno/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/meat/rawcutlet/xeno, 3, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/meat/rawcutlet/xeno, 3, TIME_TO_PROCESS_MEAT)
 
 /obj/item/food/meat/slab/xeno/MakeGrillable()
 	AddComponent(/datum/component/grillable, /obj/item/food/meat/steak/xeno, rand(40 SECONDS, 70 SECONDS), TRUE, TRUE)
@@ -827,7 +827,7 @@
 	foodtypes = RAW | MEAT | TOXIC
 
 /obj/item/food/meat/slab/spider/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/meat/rawcutlet/spider, 3, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/meat/rawcutlet/spider, 3, TIME_TO_PROCESS_MEAT)
 
 /obj/item/food/meat/slab/spider/MakeGrillable()
 	AddComponent(/datum/component/grillable, /obj/item/food/meat/steak/spider, rand(40 SECONDS, 70 SECONDS), TRUE, TRUE)
@@ -888,7 +888,7 @@
 	foodtypes = RAW | MEAT
 
 /obj/item/food/meat/slab/gondola/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/meat/rawcutlet/gondola, 3, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/meat/rawcutlet/gondola, 3, TIME_TO_PROCESS_MEAT)
 
 /obj/item/food/meat/slab/gondola/MakeGrillable()
 	AddComponent(/datum/component/grillable, /obj/item/food/meat/steak/gondola, rand(30 SECONDS, 90 SECONDS), TRUE, TRUE) //Add medium rare later maybe?
@@ -903,7 +903,7 @@
 
 /obj/item/food/meat/slab/penguin/MakeProcessable()
 	. = ..()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/meat/rawcutlet/penguin, 3, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/meat/rawcutlet/penguin, 3, TIME_TO_PROCESS_MEAT)
 
 /obj/item/food/meat/slab/penguin/MakeGrillable()
 	AddComponent(/datum/component/grillable, /obj/item/food/meat/steak/penguin, rand(30 SECONDS, 90 SECONDS), TRUE, TRUE) //Add medium rare later maybe?
@@ -938,7 +938,7 @@
 	tastes = list("chicken" = 1)
 
 /obj/item/food/meat/slab/chicken/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/meat/rawcutlet/chicken, 3, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/meat/rawcutlet/chicken, 3, TIME_TO_PROCESS_MEAT)
 
 /obj/item/food/meat/slab/chicken/MakeGrillable()
 	AddComponent(/datum/component/grillable, /obj/item/food/meat/steak/chicken, rand(30 SECONDS, 90 SECONDS), TRUE, TRUE) //Add medium rare later maybe? (no this is chicken)
@@ -1258,7 +1258,7 @@
 	venue_value = FOOD_PRICE_EXOTIC
 
 /obj/item/food/beef_wellington/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE,  /obj/item/food/beef_wellington/slice, 3, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE,  /obj/item/food/beef_wellington/slice, 3, TIME_TO_PROCESS_MEAT)
 
 /obj/item/food/beef_wellington/slice
 	name = "beef wellington slice"

--- a/code/game/objects/items/food/misc.dm
+++ b/code/game/objects/items/food/misc.dm
@@ -15,7 +15,7 @@
 	AddComponent(/datum/component/food_storage)
 
 /obj/item/food/cheese/wheel/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cheese, 5, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cheese, 5, TIME_TO_PROCESS_CHEESE)
 
 /obj/item/food/cheese/royal
 	name = "royal cheese"

--- a/code/game/objects/items/food/pie.dm
+++ b/code/game/objects/items/food/pie.dm
@@ -153,7 +153,7 @@
 	foodtypes = GRAIN | VEGETABLES | SUGAR
 
 /obj/item/food/pie/pumpkinpie/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/pieslice/pumpkin, 5, 20)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/pieslice/pumpkin, 5, TIME_TO_PROCESS_PIE)
 
 /obj/item/food/pieslice/pumpkin
 	name = "pumpkin pie slice"
@@ -212,7 +212,7 @@
 	foodtypes = GRAIN | VEGETABLES
 
 /obj/item/food/pie/blumpkinpie/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/pieslice/blumpkin, 5, 20)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/pieslice/blumpkin, 5, TIME_TO_PROCESS_PIE)
 
 /obj/item/food/pieslice/blumpkin
 	name = "blumpkin pie slice"
@@ -232,7 +232,7 @@
 	venue_value = FOOD_PRICE_EXOTIC
 
 /obj/item/food/pie/dulcedebatata/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/pieslice/dulcedebatata, 5, 20)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/pieslice/dulcedebatata, 5, TIME_TO_PROCESS_PIE)
 
 /obj/item/food/pieslice/dulcedebatata
 	name = "dulce de batata slice"
@@ -259,7 +259,7 @@
 	foodtypes = NUTS | SUGAR
 
 /obj/item/food/pie/baklava/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/pieslice/baklava, 6, 20)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/pieslice/baklava, 6, TIME_TO_PROCESS_PIE)
 
 /obj/item/food/pieslice/baklava
 	name = "baklava dish"

--- a/code/game/objects/items/food/pizza.dm
+++ b/code/game/objects/items/food/pizza.dm
@@ -14,9 +14,9 @@
 
 /obj/item/food/pizza/MakeProcessable()
 	if (slice_type)
-		AddElement(/datum/element/processable, TOOL_KNIFE, slice_type, 6, 30)
-		AddElement(/datum/element/processable, TOOL_SAW, slice_type, 6, 45)
-		AddElement(/datum/element/processable, TOOL_SCALPEL, slice_type, 6, 60)
+		AddElement(/datum/element/processable, TOOL_KNIFE, slice_type, 6, TIME_TO_PROCESS_PIZZA)
+		AddElement(/datum/element/processable, TOOL_SAW, slice_type, 6, TIME_TO_PROCESS_PIZZA)
+		AddElement(/datum/element/processable, TOOL_SCALPEL, slice_type, 6, TIME_TO_PROCESS_PIZZA)
 
 // Pizza Slice
 /obj/item/food/pizzaslice
@@ -26,7 +26,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/pizzaslice/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_ROLLINGPIN, /obj/item/stack/sheet/pizza, 1, 10)
+	AddElement(/datum/element/processable, TOOL_ROLLINGPIN, /obj/item/stack/sheet/pizza, 1, TIME_TO_PROCESS_PIZZA)
 
 
 /obj/item/food/pizza/margherita

--- a/code/modules/aquarium/fish.dm
+++ b/code/modules/aquarium/fish.dm
@@ -18,7 +18,7 @@
 		var/datum/aquarium_behaviour/fish/fish_behaviour = behaviour_type
 		var/fillet_type = initial(fish_behaviour.fillet_type)
 		if(fillet_type)
-			fish.AddElement(/datum/element/processable, TOOL_KNIFE, fillet_type, 1, 5)
+			fish.AddElement(/datum/element/processable, TOOL_KNIFE, fillet_type, 1, TIME_TO_PROCESS_FISH)
 	fish.AddElement(/datum/element/deferred_aquarium_content, behaviour_type)
 	return fish
 

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -34,7 +34,7 @@
 	wine_power = 40
 
 /obj/item/food/grown/watermelon/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/watermelonslice, 5, 20)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/watermelonslice, 5, TIME_TO_PROCESS_FRUIT)
 
 /obj/item/food/grown/watermelon/make_dryable()
 	return //No drying

--- a/code/modules/hydroponics/grown/onion.dm
+++ b/code/modules/hydroponics/grown/onion.dm
@@ -26,7 +26,7 @@
 	wine_power = 30
 
 /obj/item/food/grown/onion/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/onion_slice, 2, 15)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/onion_slice, 2, TIME_TO_PROCESS_VEGETABLE)
 
 /obj/item/seeds/onion/red
 	name = "pack of red onion seeds"
@@ -46,7 +46,7 @@
 	wine_power = 60
 
 /obj/item/food/grown/onion/red/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/onion_slice/red, 2, 15)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/onion_slice/red, 2, TIME_TO_PROCESS_VEGETABLE)
 
 /obj/item/food/grown/onion/UsedforProcessing(mob/living/user, obj/item/I, list/chosen_option)
 	var/datum/effect_system/smoke_spread/chem/S = new //Since the onion is destroyed when it's sliced,

--- a/code/modules/hydroponics/grown/pineapple.dm
+++ b/code/modules/hydroponics/grown/pineapple.dm
@@ -36,4 +36,4 @@
 
 
 /obj/item/food/grown/pineapple/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/pineappleslice, 3, 15)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/pineappleslice, 3, TIME_TO_PROCESS_FRUIT)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -48,6 +48,7 @@
 #include "code\__DEFINES\combat.dm"
 #include "code\__DEFINES\configuration.dm"
 #include "code\__DEFINES\construction.dm"
+#include "code\__DEFINES\cooking.dm"
 #include "code\__DEFINES\cooldowns.dm"
 #include "code\__DEFINES\cult.dm"
 #include "code\__DEFINES\database.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds defines that allow different types of food to be given different processing speeds as a group, rather than it being determined on a per food basis. Defaults all such defines to 1 (0.1 seconds) to make cooking much faster.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Arbitrary waits are unfun. Chefs can cook fast again.

(Addition of defines should make it easier to tweak in the future if anyone so desires.)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: Defines for time taken to process food item (per type).
qol: All food items now take only 0.1 seconds to process with a tool.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
