### PR TITLE
Replaces the goliath's 10 second stun on tendril grab with a more forgiving alternative.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -218,14 +218,21 @@
 		if((!QDELETED(spawner) && spawner.faction_check_mob(L)) || L.stat == DEAD)
 			continue
 		visible_message(span_danger("[src] grabs hold of [L]!"))
-		L.Stun(100)
-		L.adjustBruteLoss(rand(10,15))
+		INVOKE_ASYNC(src, PROC_REF(handle_tendril_grab), L)
 		latched = TRUE
 	if(!latched)
 		retract()
 	else
 		deltimer(timerid)
 		timerid = addtimer(CALLBACK(src, PROC_REF(retract)), 10, TIMER_STOPPABLE)
+
+/obj/effect/temp_visual/goliath_tentacle/proc/handle_tendril_grab(mob/living/L)
+	L.adjustBruteLoss(rand(10,15))
+	L.Knockdown(5 SECONDS)
+	L.Stun(3 SECONDS)
+	L.add_movespeed_modifier(/datum/movespeed_modifier/goliath_tendril)
+	sleep(8.5 SECONDS)
+	L.remove_movespeed_modifier(/datum/movespeed_modifier/goliath_tendril)
 
 /obj/effect/temp_visual/goliath_tentacle/proc/retract()
 	icon_state = "Goliath_tentacle_retract"

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -126,3 +126,6 @@
 
 /datum/movespeed_modifier/morph_disguised
 	multiplicative_slowdown = 1
+
+/datum/movespeed_modifier/goliath_tendril
+	multiplicative_slowdown = 0.5


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Replaces the 10 second stun of the goliath's tendrils with a milder combination of knockdown (5 seconds), stun (3 seconds) and minor movespeed penalty (8.5 seconds).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Makes goliaths more forgiving, hopefully resulting in fewer dead miners and the role being more approachable for beginners.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Replaces the goliath's 10 second stun with an overall milder combination of knockdown, stun and movespeed penalty.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
