### PR TITLE
Reimplements the HARS technique with exceptions for certain traumas.

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -484,6 +484,9 @@
 	var/obj/item/organ/brain/brain = owner.getorganslot(ORGAN_SLOT_BRAIN)
 	if(brain)
 		brain.zone = BODY_ZONE_CHEST
+		for (var/datum/brain_trauma/trauma in brain.traumas)
+			if !(istype(trauma, /datum/brain_trauma/magic) || (istype(trauma, /datum/brain_trauma/mild/phobia) && (/datum/quirk/phobia in owner.quirks)) || istype(trauma, /datum/brain_trauma/mild/phobia/ocky_icky) || /datum/brain_trauma/severe/paralysis/paraplegic)
+				qdel(trauma)
 
 	var/obj/item/bodypart/head/head = owner.get_bodypart(BODY_ZONE_HEAD)
 	if(head)

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -485,7 +485,7 @@
 	if(brain)
 		brain.zone = BODY_ZONE_CHEST
 		for (var/datum/brain_trauma/trauma in brain.traumas)
-			if !(istype(trauma, /datum/brain_trauma/magic) || (istype(trauma, /datum/brain_trauma/mild/phobia) && (/datum/quirk/phobia in owner.quirks)) || istype(trauma, /datum/brain_trauma/mild/phobia/ocky_icky) || /datum/brain_trauma/severe/paralysis/paraplegic)
+			if (!(istype(trauma, /datum/brain_trauma/magic) || (istype(trauma, /datum/brain_trauma/mild/phobia) && owner.has_quirk(/datum/quirk/phobia)) || istype(trauma, /datum/brain_trauma/mild/phobia/ocky_icky) || (istype(trauma, /datum/brain_trauma/severe/paralysis/paraplegic) && owner.has_quirk(/datum/quirk/paraplegic))))
 				qdel(trauma)
 
 	var/obj/item/bodypart/head/head = owner.get_bodypart(BODY_ZONE_HEAD)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reimplements the HARS technique (applying HARS to a patient and then removing it to cure deep-rooted traumas) with a filter that prevents the act from removing certain magical, admin and quirk related traumas.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The way lobotomies currently work makes them a trap option that causes more harm than good; at the same time, having no alternative treatment for what cessentially amounts to being screwed over by RNG is really lame. The reimplementation of the HARS technique not only remedies this issue but encourages interdepartmental cooperation as a bonus.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Reimplements the HARS technique.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
