### PR TITLE
Bank machine improvements: ports TG PRs #80394 and #78331.

### DIFF
--- a/code/game/machinery/bank_machine.dm
+++ b/code/game/machinery/bank_machine.dm
@@ -43,8 +43,11 @@
 /obj/machinery/computer/bank_machine/process(delta_time)
 	..()
 	if(siphoning)
-		if (machine_stat & (BROKEN|NOPOWER))
+		if(machine_stat & (BROKEN|NOPOWER))
 			say("Insufficient power. Halting siphon.")
+			end_syphon()
+		else if(!(is_station_level(src.z) || is_centcom_level(src.z)))
+			say("Error: Console not in reach of station. Siphon halted.")
 			end_syphon()
 		var/siphon_am = 100 * delta_time
 		var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
@@ -88,8 +91,11 @@
 
 	switch(action)
 		if("siphon")
-			say("Siphon of station credits has begun!")
-			siphoning = TRUE
+			if(is_station_level(src.z) || is_centcom_level(src.z))
+				say("Siphon of station credits has begun!")
+				siphoning = TRUE
+			else
+				say("Error: Console not in reach of station, withdrawal cannot begin.")
 			. = TRUE
 		if("halt")
 			say("Station credit withdrawal halted.")
@@ -98,5 +104,6 @@
 
 /obj/machinery/computer/bank_machine/proc/end_syphon()
 	siphoning = FALSE
-	new /obj/item/holochip(drop_location(), syphoning_credits) //get the loot
+	if(syphoning_credits > 0)
+		new /obj/item/holochip(drop_location(), syphoning_credits) //get the loot
 	syphoning_credits = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Credit to [Majkl-J](https://github.com/Majkl-J) and [mc-oofert](https://github.com/mc-oofert) for the changes.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

#78331 fixes a bug. #80394 isn't needed for us currently as the bank machine is unmovable and lacks a circuitboard, however, it serves as a small amount of futureproofing.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Bank machines are now prevented from siphoning station credits from off-Z.
fix: Fixes bank machine printing 0 cr bills.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
