### PR TITLE
Increases the spawn chance of wittle and plasma-oxide geysers.

### DIFF
--- a/code/datums/mapgen/Cavegens/IcemoonCaves.dm
+++ b/code/datums/mapgen/Cavegens/IcemoonCaves.dm
@@ -9,7 +9,7 @@
 						  /mob/living/simple_animal/hostile/asteroid/lobstrosity = 15)
 	flora_spawn_list = list(/obj/structure/flora/tree/pine = 2, /obj/structure/flora/rock/icy = 2, /obj/structure/flora/rock/pile/icy = 2, /obj/structure/flora/grass/both = 6, /obj/structure/flora/ash/chilly = 2)
 	///Note that this spawn list is also in the lavaland generator
-	feature_spawn_list = list(/obj/structure/geyser/wittel = 6, /obj/structure/geyser/random = 2, /obj/structure/geyser/plasma_oxide = 10, /obj/structure/geyser/protozine = 10, /obj/structure/geyser/hollowwater = 10)
+	feature_spawn_list = list(/obj/structure/geyser/wittel = 10, /obj/structure/geyser/random = 2, /obj/structure/geyser/plasma_oxide = 12, /obj/structure/geyser/protozine = 10, /obj/structure/geyser/hollowwater = 10)
 
 /datum/map_generator/cave_generator/icemoon/surface
 	flora_spawn_chance = 4

--- a/code/datums/mapgen/Cavegens/LavalandGenerator.dm
+++ b/code/datums/mapgen/Cavegens/LavalandGenerator.dm
@@ -9,7 +9,7 @@
 		SPAWN_MEGAFAUNA = 4, /mob/living/simple_animal/hostile/asteroid/goldgrub = 10)
 	flora_spawn_list = list(/obj/structure/flora/ash/leaf_shroom = 2 , /obj/structure/flora/ash/cap_shroom = 2 , /obj/structure/flora/ash/stem_shroom = 2 , /obj/structure/flora/ash/cacti = 1, /obj/structure/flora/ash/tall_shroom = 2, /obj/structure/flora/ash/seraka = 2)
 	///Note that this spawn list is also in the icemoon generator
-	feature_spawn_list = list(/obj/structure/geyser/wittel = 6, /obj/structure/geyser/random = 2, /obj/structure/geyser/plasma_oxide = 10, /obj/structure/geyser/protozine = 10, /obj/structure/geyser/hollowwater = 10)
+	feature_spawn_list = list(/obj/structure/geyser/wittel = 10, /obj/structure/geyser/random = 2, /obj/structure/geyser/plasma_oxide = 12, /obj/structure/geyser/protozine = 10, /obj/structure/geyser/hollowwater = 10)
 
 	initial_closed_chance = 45
 	smoothing_iterations = 50


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Wittle and plasma-oxide geysers should now spawn more often.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Wittle is ridiculously rare for a gimmick chem and is almost never used. Plasma-oxide has the potential to be strong due to its use in exotic stabiliser but is almost never sought after. Increasing the spawn chance of both should promote chemists seeking out these chems.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Wittle and plasma-oxide geysers spawn more frequently.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
