### PR TITLE
Neurotoxin spit stun duration scales down based on bio armor.

### DIFF
--- a/code/modules/projectiles/projectile/special/neurotoxin.dm
+++ b/code/modules/projectiles/projectile/special/neurotoxin.dm
@@ -12,4 +12,7 @@
 	if(isalien(target))
 		paralyze = 0
 		nodamage = TRUE
+	if(ishuman(target))
+		var/mob/living/carbon/human/H = target
+		paralyze = clamp((paralyze - H.getarmor(null, BIO)), 10, 100) //minimum stun time can be reduced to is 1 second
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Subtracts from the stun duration of neurotoxin spit the amount of bio armor the target it's hitting has, down to a minimum stun duration of 1 second from a default of 10.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Neurotoxin spit is widely considered to be busted. If this doesn't work in balance's favor, we can revert it.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: The stun duration of neurotoxin spit is now scaled down by bio armor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
