### PR TITLE
Humanoids are once again able to dodge immovable rods by lying down.

### DIFF
--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -231,7 +231,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 		if(ishuman(clong))
 			var/mob/living/carbon/human/H = clong
 			if(H.body_position == LYING_DOWN) // Unless they're specifically lying down.
-				return ..()
+				return
 		penetrate(clong)
 		return ..()
 

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -228,6 +228,10 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 
 	// If we Bump into a living thing, living thing goes splat.
 	if(isliving(clong))
+		if(ishuman(clong))
+			var/mob/living/carbon/human/H = clong
+			if(H.body_position == LYING_DOWN) // Unless they're specifically lying down.
+				return ..()
 		penetrate(clong)
 		return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Immovable rods now skip over humanoids who are lying down when it enters their tile.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Unreactable stuff a cringe.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Corporate mandated training in the not-Matrix has enabled crew to dodge immovable rods by simply lying down.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
