### PR TITLE
Nightshift lighting has been made dimmer overall with the degree varying by department area.

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -18,6 +18,16 @@
 //How many reagents the lights can hold
 #define LIGHT_REAGENT_CAPACITY 5
 
+//For variable nightshift lighting
+#define NIGHTSHIFT_DEFAULT_BRIGHTNESS 4
+#define NIGHTSHIFT_DEFAULT_LIGHTPOWER 0.25
+//Used in the kitchen and cargo
+#define NIGHTSHIFT_INCREASED_BRIGHTNESS 6
+#define NIGHTSHIFT_INCREASED_LIGHTPOWER 0.35
+//Used in hydroponics and medbay
+#define NIGHTSHIFT_FULL_BRIGHTNESS 8
+#define NIGHTSHIFT_FULL_LIGHTPOWER 0.45
+
 /obj/item/wallframe/light_fixture
 	name = "light fixture frame"
 	desc = "Used for building lights."
@@ -240,8 +250,8 @@
 
 	var/nightshift_enabled = FALSE //Currently in night shift mode?
 	var/nightshift_allowed = TRUE //Set to FALSE to never let this light get switched to night mode.
-	var/nightshift_brightness = 8
-	var/nightshift_light_power = 0.45
+	var/nightshift_brightness = NIGHTSHIFT_DEFAULT_BRIGHTNESS
+	var/nightshift_light_power = NIGHTSHIFT_DEFAULT_LIGHTPOWER
 	var/nightshift_light_color = "#FFDDCC"
 
 	var/emergency_mode = FALSE // if true, the light is in emergency mode

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -434,6 +434,16 @@
 		if (A?.fire)
 			CO = bulb_emergency_colour
 		else if (nightshift_enabled)
+			//We check where the lightsource is located and update the nightshift variables accordingly
+			var/station_area = get_area_name(src)
+			switch(station_area)
+				if("Hydroponics", "Exam Room", "Cryogenics")
+					nightshift_brightness = NIGHTSHIFT_FULL_BRIGHTNESS
+					nightshift_light_power = NIGHTSHIFT_FULL_LIGHTPOWER
+				if("Kitchen", "Cargo Bay")
+					nightshift_brightness = NIGHTSHIFT_INCREASED_BRIGHTNESS
+					nightshift_light_power = NIGHTSHIFT_INCREASED_LIGHTPOWER
+			//Set the nightshift variables
 			BR = nightshift_brightness
 			PO = nightshift_light_power
 			if(!color)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -437,10 +437,10 @@
 			//We check where the lightsource is located and update the nightshift variables accordingly
 			var/station_area = get_area_name(src)
 			switch(station_area)
-				if("Hydroponics", "Exam Room", "Cryogenics")
+				if("Hydroponics", "Exam Room", "Cryogenics", "Surgery A", "Surgery B", "Surgery C", "Surgery D")
 					nightshift_brightness = NIGHTSHIFT_FULL_BRIGHTNESS
 					nightshift_light_power = NIGHTSHIFT_FULL_LIGHTPOWER
-				if("Kitchen", "Cargo Bay")
+				if("Kitchen", "Cargo Bay", "Robotics Lab")
 					nightshift_brightness = NIGHTSHIFT_INCREASED_BRIGHTNESS
 					nightshift_light_power = NIGHTSHIFT_INCREASED_LIGHTPOWER
 			//Set the nightshift variables


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Nightshift lighting now comes in three levels, the default of which is the dimmest. Some areas, where more visibility would make sense, take slightly brighter lighting instead (though still less than before).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Improves atmosphere and gives antags more opportunities to ambush people in the dark.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Darker overall nightshifts.
add: Some areas of the station have nightshift lighting that isn't as dim as the rest.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
