### PR TITLE
Basic mummy clothing can be crafted without a null rod, now uses gauze instead of cloth. Adds an armored variant involving the rod.

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -809,12 +809,24 @@
 	name = "Mummification Bandages (Mask)"
 	result = /obj/item/clothing/mask/mummy
 	time = 10
-	tool_paths = list(/obj/item/nullrod/egyptian)
 	reqs = list(/obj/item/stack/sheet/cloth = 2)
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/mummy/body
 	name = "Mummification Bandages (Body)"
+	result = /obj/item/clothing/under/costume/mummy
+	reqs = list(/obj/item/stack/sheet/cloth = 5)
+
+/datum/crafting_recipe/mummy/magic
+	name = "Imbued Mummification Bandages (Mask)"
+	result = /obj/item/clothing/mask/mummy
+	time = 10
+	tool_paths = list(/obj/item/nullrod/egyptian)
+	reqs = list(/obj/item/stack/sheet/cloth = 2)
+	category = CAT_CLOTHING
+
+/datum/crafting_recipe/mummy/body/magic
+	name = "Imbued Mummification Bandages (Body)"
 	result = /obj/item/clothing/under/costume/mummy
 	reqs = list(/obj/item/stack/sheet/cloth = 5)
 

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -809,26 +809,26 @@
 	name = "Mummification Bandages (Mask)"
 	result = /obj/item/clothing/mask/mummy
 	time = 10
-	reqs = list(/obj/item/stack/sheet/cloth = 2)
+	reqs = list(/obj/item/stack/medical/gauze = 2)
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/mummy/body
 	name = "Mummification Bandages (Body)"
 	result = /obj/item/clothing/under/costume/mummy
-	reqs = list(/obj/item/stack/sheet/cloth = 5)
+	reqs = list(/obj/item/stack/medical/gauze = 5)
 
-/datum/crafting_recipe/mummy/magic
+/datum/crafting_recipe/imbued_mummy
 	name = "Imbued Mummification Bandages (Mask)"
-	result = /obj/item/clothing/mask/mummy
+	result = /obj/item/clothing/mask/mummy/magic
 	time = 10
 	tool_paths = list(/obj/item/nullrod/egyptian)
-	reqs = list(/obj/item/stack/sheet/cloth = 2)
+	reqs = list(/obj/item/stack/medical/gauze = 2, /obj/item/stack/ore/glass = 1)
 	category = CAT_CLOTHING
 
-/datum/crafting_recipe/mummy/body/magic
+/datum/crafting_recipe/imbued_mummy/body
 	name = "Imbued Mummification Bandages (Body)"
-	result = /obj/item/clothing/under/costume/mummy
-	reqs = list(/obj/item/stack/sheet/cloth = 5)
+	result = /obj/item/clothing/under/costume/mummy/magic
+	reqs = list(/obj/item/stack/medical/gauze = 5, /obj/item/stack/ore/glass = 2)
 
 /datum/crafting_recipe/chaplain_hood
 	name = "Follower Hoodie"

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -180,10 +180,15 @@
 
 /obj/item/clothing/mask/mummy
 	name = "mummy mask"
-	desc = "Ancient bandages."
+	desc = "Allegedly, ancient bandages."
 	icon_state = "mummy_mask"
 	inhand_icon_state = "mummy_mask"
 	flags_inv = HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
+
+/obj/item/clothing/mask/mummy/magic
+	name = "imbued mummy mask"
+	desc = "A headwrap of bandages, twinkling with forgotten power."
+	armor = list(MELEE = 10, LASER = 20, FIRE = 30)
 
 /obj/item/clothing/mask/scarecrow
 	name = "sack mask"

--- a/code/modules/clothing/under/costume.dm
+++ b/code/modules/clothing/under/costume.dm
@@ -167,6 +167,11 @@
 	can_adjust = FALSE
 	resistance_flags = NONE
 
+/obj/item/clothing/under/costume/mummy/magic
+	name = "imbued mummy wrapping"
+	desc = "The wraps are faintly glowing with the light of Ra. At least, you hope it's the light of Ra."
+	armor = list(MELEE = 10, LASER = 20, FIRE = 30)
+
 /obj/item/clothing/under/costume/scarecrow
 	name = "scarecrow clothes"
 	desc = "Perfect camouflage for hiding in botany."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The basic mummy clothing (body and mask) uses gauze rather than cloth in its recipe and no longer requires the egyptian staff null rod to craft. Adds an "imbued" variant made using the staff with sand as an extra ingredient, this variant offers a small amount of protection against the brute, laser and fire damage types.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Creates more opportunity for crew gimmicks by freeing the basic clothing items and provides more incentive for chaplains to consider taking the egyptian staff, a rarely-chosen option.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Chaplains can use the egyptian staff variant of the null rod to craft a lightly armored version of the mummy clothing (requires gauze and sand).
balance: Mummy clothing items can be crafted by any crewperson and use gauze instead of cloth.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
