### PR TITLE
Cargo can opt out of receiving mail using the cargo console.

### DIFF
--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -203,7 +203,7 @@
 		if("togglemail")
 			if(is_express)
 				return
-			SSshuttle.supply.receive_mail = !(SShuttle.supply.receive_mail)
+			SSshuttle.supply.receive_mail = !(SSshuttle.supply.receive_mail)
 			. = TRUE
 		if("add")
 			if(is_express)

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -97,6 +97,7 @@
 /obj/machinery/computer/cargo/ui_data()
 	var/list/data = list()
 	data["location"] = SSshuttle.supply.getStatusText()
+	data["receive_mail"] = SSshuttle.supply.receive_mail
 	var/datum/bank_account/D = SSeconomy.get_dep_account(cargo_account)
 	if(D)
 		data["points"] = D.account_balance
@@ -199,6 +200,11 @@
 				investigate_log("[key_name(usr)] accepted a shuttle loan event.", INVESTIGATE_CARGO)
 				log_game("[key_name(usr)] accepted a shuttle loan event.")
 				. = TRUE
+		if("togglemail")
+			if(is_express)
+				return
+			SSshuttle.supply.receive_mail = !(SShuttle.supply.receive_mail)
+			. = TRUE
 		if("add")
 			if(is_express)
 				return

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -52,9 +52,10 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 	height = 7
 	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0)
 
-
 	//Export categories for this run, this is set by console sending the shuttle.
 	var/export_categories = EXPORT_CARGO
+	//Are we going to generate mail? (also set in the console)
+	var/receive_mail = FALSE
 
 /obj/docking_port/mobile/supply/register()
 	. = ..()
@@ -82,7 +83,8 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 /obj/docking_port/mobile/supply/initiate_docking()
 	if(getDockedId() == "supply_away") // Buy when we leave home.
 		buy()
-		create_mail()
+		if(receive_mail)
+			create_mail()
 	. = ..() // Fly/enter transit.
 	if(. != DOCKING_SUCCESS)
 		return

--- a/tgui/packages/tgui/interfaces/Cargo.js
+++ b/tgui/packages/tgui/interfaces/Cargo.js
@@ -83,6 +83,7 @@ const CargoStatus = (props, context) => {
     points,
     requestonly,
     can_send,
+    receive_mail,
   } = data;
   return (
     <Section
@@ -123,6 +124,10 @@ const CargoStatus = (props, context) => {
             )}
           </LabeledList.Item>
         )}
+        <Button.Checkbox
+          content="Receive mail?"
+          checked={receive_mail}
+          onClick={() => act('togglemail')} />
       </LabeledList>
     </Section>
   );

--- a/tgui/packages/tgui/interfaces/Cargo.js
+++ b/tgui/packages/tgui/interfaces/Cargo.js
@@ -124,10 +124,12 @@ const CargoStatus = (props, context) => {
             )}
           </LabeledList.Item>
         )}
-        <Button.Checkbox
-          content="Receive mail?"
-          checked={receive_mail}
-          onClick={() => act('togglemail')} />
+        <LabeledList.Item label="Mail Options">
+          {<Button.Checkbox
+            content="Receive mail?"
+            checked={receive_mail}
+            onClick={() => act('togglemail')} />}
+        </LabeledList.Item>
       </LabeledList>
     </Section>
   );


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a checkbox to the cargo console that allows cargo to opt out of receiving mail aboard the next cargo shuttle.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Oftentimes, with noone willing to deliver mail, it piles up in the cargo lobby, or, worse, the cargo airlock. This change allows cargo to operate more efficiently and with less clutter, if they so choose.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Cargo can opt out of receiving mail using the cargo console.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
