### PR TITLE
Removes the ability of ninjas to emag airlocks and cyborgs with their gloves.

### DIFF
--- a/code/modules/antagonists/space_ninja/space_ninja.dm
+++ b/code/modules/antagonists/space_ninja/space_ninja.dm
@@ -42,13 +42,6 @@
 	antag_memory += "I am an elite mercenary of the mighty Spider Clan. A <font color='red'><B>SPACE NINJA</B></font>!<br>"
 	antag_memory += "Surprise is my weapon. Shadows are my armor. Without them, I am nothing. (//initialize your suit by clicking the initialize UI button, to use abilities like stealth)!<br>"
 
-/datum/objective/cyborg_hijack
-	explanation_text = "Use your gloves to convert at least one cyborg to aide you in sabotaging the station."
-
-/datum/objective/door_jack
-	///How many doors that need to be opened using the gloves to pass the objective
-	var/doors_required = 0
-
 /datum/objective/plant_explosive
 	var/area/detonation_location
 
@@ -64,21 +57,11 @@
  * Proc that adds all the ninja's objectives to the antag datum.  Called when the datum is gained.
  */
 /datum/antagonist/ninja/proc/addObjectives()
-	//Cyborg Hijack: Flag set to complete in the DrainAct in ninjaDrainAct.dm
-	var/datum/objective/hijack = new /datum/objective/cyborg_hijack()
-	objectives += hijack
-
 	//Research stealing
 	var/datum/objective/download/research = new /datum/objective/download()
 	research.owner = owner
 	research.gen_amount_goal()
 	objectives += research
-
-	//Door jacks, flag will be set to complete on when the last door is hijacked
-	var/datum/objective/door_jack/doorobjective = new /datum/objective/door_jack()
-	doorobjective.doors_required = rand(15,40)
-	doorobjective.explanation_text = "Use your gloves to doorjack [doorobjective.doors_required] airlocks on the station."
-	objectives += doorobjective
 
 	//Explosive plant, the bomb will register its completion on priming
 	var/datum/objective/plant_explosive/bombobjective = new /datum/objective/plant_explosive()

--- a/code/modules/ninja/suit/ninjaDrainAct.dm
+++ b/code/modules/ninja/suit/ninjaDrainAct.dm
@@ -181,21 +181,6 @@
 		if(objective)
 			objective.completed = TRUE
 
-//AIRLOCK//
-/obj/machinery/door/airlock/ninjadrain_act(obj/item/clothing/suit/space/space_ninja/ninja_suit, mob/living/carbon/human/ninja, obj/item/clothing/gloves/space_ninja/ninja_gloves)
-	if(!ninja_suit || !ninja || !ninja_gloves)
-		return INVALID_DRAIN
-
-	if(!operating && density && hasPower() && !(obj_flags & EMAGGED))
-		emag_act()
-		ninja_gloves.door_hack_counter++
-		var/datum/antagonist/ninja/ninja_antag = ninja.mind.has_antag_datum(/datum/antagonist/ninja)
-		if(!ninja_antag)
-			return
-		var/datum/objective/door_jack/objective = locate() in ninja_antag.objectives
-		if(objective && objective.doors_required <= ninja_gloves.door_hack_counter)
-			objective.completed = TRUE
-
 //WIRE//
 /obj/structure/cable/ninjadrain_act(obj/item/clothing/suit/space/space_ninja/ninja_suit, mob/living/carbon/human/ninja, obj/item/clothing/gloves/space_ninja/ninja_gloves)
 	if(!ninja_suit || !ninja || !ninja_gloves)
@@ -262,30 +247,6 @@
 				break
 
 	return drain_total
-
-//BORG//
-/mob/living/silicon/robot/ninjadrain_act(obj/item/clothing/suit/space/space_ninja/ninja_suit, mob/living/carbon/human/ninja, obj/item/clothing/gloves/space_ninja/ninja_gloves)
-	if(!ninja_suit || !ninja || !ninja_gloves || (ROLE_NINJA in faction))
-		return INVALID_DRAIN
-
-	to_chat(src, span_danger("Warni-***BZZZZZZZZZRT*** UPLOADING SPYDERPATCHER VERSION 9.5.2..."))
-	if (do_after(ninja, 60, target = src))
-		spark_system.start()
-		playsound(loc, "sparks", 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-		to_chat(src, span_danger("UPLOAD COMPLETE. NEW CYBORG MODEL DETECTED.  INSTALLING..."))
-		faction = list(ROLE_NINJA)
-		bubble_icon = "syndibot"
-		UnlinkSelf()
-		ionpulse = TRUE
-		laws = new /datum/ai_laws/ninja_override()
-		model.transform_to(pick(/obj/item/robot_model/syndicate, /obj/item/robot_model/syndicate_medical, /obj/item/robot_model/saboteur))
-
-		var/datum/antagonist/ninja/ninja_antag = ninja.mind.has_antag_datum(/datum/antagonist/ninja)
-		if(!ninja_antag)
-			return
-		var/datum/objective/cyborg_hijack/objective = locate() in ninja_antag.objectives
-		if(objective)
-			objective.completed = TRUE
 
 //CARBON MOBS//
 /mob/living/carbon/ninjadrain_act(obj/item/clothing/suit/space/space_ninja/ninja_suit, mob/living/carbon/human/ninja, obj/item/clothing/gloves/space_ninja/ninja_gloves)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ninjas can no longer emag airlocks and cyborgs with their gloves and their objectives to do so have been removed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Reworked ninja is more of a nuisance than anything else, their door hacking objective leading to mass depressurisation is simply not fun to play against, neither is the army of borgs that they can whip up, and this change will make them significantly less annoying.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Removed the ability of ninjas to emag airlocks and cyborgs with their gloves.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
