### PR TITLE
Adds two new, weak healing chems to go in firstaid kits.

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -32,8 +32,8 @@
 		return
 	var/static/items_inside = list(
 		/obj/item/stack/medical/gauze = 1,
-		/obj/item/reagent_containers/pill/patch/libital = 2,
-		/obj/item/reagent_containers/pill/patch/aiuri = 2,
+		/obj/item/reagent_containers/pill/patch/colpisbital = 2,
+		/obj/item/reagent_containers/pill/patch/cremiisuri = 2,
 		/obj/item/reagent_containers/hypospray/medipen = 1,
 		/obj/item/storage/pill_bottle/paracetamol = 1)
 	generate_items_inside(items_inside,src)

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -86,12 +86,21 @@
 	taste_description = "bitter with a hint of alcohol"
 	reagent_state = SOLID
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	var/brute_heal_amount = -3
+	var/liver_damage_amount = 0.3
 
 /datum/reagent/medicine/c2/libital/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
-	M.adjustOrganLoss(ORGAN_SLOT_LIVER, 0.3 * REM * delta_time)
-	M.adjustBruteLoss(-3 * REM * delta_time)
+	M.adjustOrganLoss(ORGAN_SLOT_LIVER, liver_damage_amount * REM * delta_time)
+	M.adjustBruteLoss(brute_heal_amount * REM * delta_time)
 	..()
 	return TRUE
+
+/datum/reagent/medicine/c2/libital/colpisbital //diluted libital, half as effective
+	name = "Colpisbital"
+	description = "Diluted medicine used to treat brute. Does minor liver damage."
+	color = "#ebebbe"
+	brute_heal_amount = -1.5
+	liver_damage_amount = 0.15
 
 /datum/reagent/medicine/c2/probital
 	name = "Probital"
@@ -160,12 +169,21 @@
 	var/resetting_probability = 0
 	var/message_cd = 0
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	var/burn_heal_amount = -2
+	var/eye_damage_amount = 0.25
 
 /datum/reagent/medicine/c2/aiuri/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
-	M.adjustFireLoss(-2 * REM * delta_time)
-	M.adjustOrganLoss(ORGAN_SLOT_EYES, 0.25 * REM * delta_time)
+	M.adjustFireLoss(burn_heal_amount * REM * delta_time)
+	M.adjustOrganLoss(ORGAN_SLOT_EYES, eye_damage_amount * REM * delta_time)
 	..()
 	return TRUE
+
+/datum/reagent/medicine/c2/aiuri/cremiisuri //diluted aiuri, half as effective
+	name = "Cremiisuri"
+	description = "Diluted medicine used to treat burns. Does minor eye damage."
+	color = "#9aa0fc"
+	burn_heal_amount = -1
+	eye_damage_amount = 0.125
 
 /datum/reagent/medicine/c2/hercuri
 	name = "Hercuri"

--- a/code/modules/reagents/chemistry/recipes/cat2_medicines.dm
+++ b/code/modules/reagents/chemistry/recipes/cat2_medicines.dm
@@ -13,6 +13,10 @@
 	required_reagents = list(/datum/reagent/phenol = 1, /datum/reagent/oxygen = 1, /datum/reagent/nitrogen = 1)
 	required_temp = 225
 
+/datum/chemical_reaction/medicine/colpisbital
+	results = list(/datum/reagent/medicine/c2/libital/colpisbital = 4)
+	required_reagents = list(/datum/reagent/medicine/c2/libital = 2, /datum/reagent/water = 1, /datum/reagent/consumable/ethanol = 1)
+
 /datum/chemical_reaction/medicine/probital
 	results = list(/datum/reagent/medicine/c2/probital = 4)
 	required_reagents = list(/datum/reagent/copper = 1, /datum/reagent/acetone = 2,  /datum/reagent/phosphorus = 1)
@@ -32,6 +36,10 @@
 	results = list(/datum/reagent/medicine/c2/aiuri = 4)
 	required_reagents = list(/datum/reagent/ammonia = 1, /datum/reagent/toxin/acid = 1, /datum/reagent/hydrogen = 2)
 	required_temp = 50
+
+/datum/chemical_reaction/medicine/cremiisuri
+	results = list(/datum/reagent/medicine/c2/aiuri/cremiisuri = 4)
+	required_reagents = list(/datum/reagent/medicine/c2/aiuri = 2, /datum/reagent/water = 1, /datum/reagent/consumable/ethanol = 1)
 
 /datum/chemical_reaction/medicine/hercuri
 	results = list(/datum/reagent/medicine/c2/hercuri = 5)

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -29,7 +29,7 @@
 
 /obj/item/reagent_containers/pill/patch/libital
 	name = "libital patch (brute)"
-	desc = "A pain reliever. Does minor liver damage. Diluted with Granibitaluri."
+	desc = "Alleviates bruising. Does minor liver damage. Diluted with Granibitaluri."
 	list_reagents = list(/datum/reagent/medicine/c2/libital = 2, /datum/reagent/medicine/granibitaluri = 8) //10 iterations
 	icon_state = "bandaid_brute"
 

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -29,18 +29,30 @@
 
 /obj/item/reagent_containers/pill/patch/libital
 	name = "libital patch (brute)"
-	desc = "Alleviates bruising. Does minor liver damage. Diluted with Granibitaluri."
-	list_reagents = list(/datum/reagent/medicine/c2/libital = 2, /datum/reagent/medicine/granibitaluri = 8) //10 iterations
+	desc = "Alleviates bruising; does minor liver damage. Diluted with Granibitaluri."
+	list_reagents = list(/datum/reagent/medicine/c2/libital = 4, /datum/reagent/medicine/granibitaluri = 6)
+	icon_state = "bandaid_brute"
+
+/obj/item/reagent_containers/pill/patch/colpisbital
+	name = "colpisbital patch (brute)"
+	desc = "Alleviates light bruising but does minor liver damage. Also contains: Granibitaluri."
+	list_reagents = list(/datum/reagent/medicine/c2/libital/colpisbital = 4, /datum/reagent/medicine/granibitaluri = 6)
 	icon_state = "bandaid_brute"
 
 /obj/item/reagent_containers/pill/patch/aiuri
 	name = "aiuri patch (burn)"
-	desc = "Helps with burn injuries. Does minor eye damage. Diluted with Granibitaluri."
-	list_reagents = list(/datum/reagent/medicine/c2/aiuri = 2, /datum/reagent/medicine/granibitaluri = 8)
+	desc = "Heals burn injuries; does minor eye damage. Diluted with Granibitaluri."
+	list_reagents = list(/datum/reagent/medicine/c2/aiuri = 6, /datum/reagent/medicine/granibitaluri = 4)
+	icon_state = "bandaid_burn"
+
+/obj/item/reagent_containers/pill/patch/cremiisuri
+	name = "cremiisuri patch (burn)"
+	desc = "Heals mild burn injuries but does minor eye damage. Also contains: Granibitaluri."
+	list_reagents = list(/datum/reagent/medicine/c2/aiuri/cremiisuri = 6, /datum/reagent/medicine/granibitaluri = 4)
 	icon_state = "bandaid_burn"
 
 /obj/item/reagent_containers/pill/patch/synthflesh
 	name = "synthflesh patch"
-	desc = "Helps with brute and burn injuries. Slightly toxic."
+	desc = "Heals both brute and burn injuries. Toxic."
 	list_reagents = list(/datum/reagent/medicine/c2/synthflesh = 20)
 	icon_state = "bandaid_both"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds colpisbital (half-strength libital) and cremiisuri (half-strength aiuri), both made my mixing two parts of their parent reagent with one part ethanol and one part water.

Also buffs libital and aiuri patches (and tweaks the chem volumes in them to make them comparable to eachother in terms of effectiveness) but removes them from standard firstaid kits, swapping in patches of the new chems.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Achieves a clear, three-tier core healing chem structure for both brute and burn meds, where less-common chems perform better and are centralized within medbay.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: New brute healing chem, Colpisbital.
add: New burn healing chem, Cremiisuri.
balance: Buffs Libital and Aiuri patches.
balance: Standard firstaid kits contain Colpisbital/Cremiisuri patches, instead of Libital/Aiuri ones.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
