### PR TITLE
Removes a few station traits and nerfs crew deathrattle.

### DIFF
--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -48,7 +48,6 @@
 	. = ..()
 	RegisterSignal(SSdcs, COMSIG_GLOB_JOB_AFTER_LATEJOIN_SPAWN, PROC_REF(on_job_after_spawn))
 
-
 /datum/station_trait/hangover/proc/on_job_after_spawn(datum/source, datum/job/job, mob/living/spawned_mob)
 	SIGNAL_HANDLER
 
@@ -66,29 +65,14 @@
 	hat = new hat(spawned_mob)
 	spawned_mob.equip_to_slot_or_del(hat, ITEM_SLOT_HEAD)
 
-
-/datum/station_trait/blackout
-	name = "Blackout"
-	trait_type = STATION_TRAIT_NEGATIVE
-	weight = 3
-	show_in_report = TRUE
-	report_message = "Station lights seem to be damaged, be safe when starting your shift today."
-
-/datum/station_trait/blackout/on_round_start()
-	. = ..()
-	for(var/obj/machinery/power/apc/apc as anything in GLOB.apcs_list)
-		if(is_station_level(apc.z) && prob(60))
-			apc.overload_lighting()
-
 /datum/station_trait/empty_maint
 	name = "Cleaned out maintenance"
 	trait_type = STATION_TRAIT_NEGATIVE
 	weight = 5
 	show_in_report = TRUE
-	report_message = "Our workers cleaned out most of the junk in the maintenace areas."
+	report_message = "Our workers cleaned out most of the junk in the maintenance areas."
 	blacklist = list(/datum/station_trait/filled_maint)
 	trait_to_give = STATION_TRAIT_EMPTY_MAINT
-
 
 /datum/station_trait/overflow_job_bureaucracy
 	name = "Overflow bureaucracy mistake"

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -43,7 +43,6 @@
 		dog.forceMove(adventure_turf)
 		do_smoke(location=adventure_turf)
 
-
 /datum/station_trait/glitched_pdas
 	name = "PDA glitch"
 	trait_type = STATION_TRAIT_NEUTRAL

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -1,36 +1,3 @@
-#define PARTY_COOLDOWN_LENGTH_MIN 6 MINUTES
-#define PARTY_COOLDOWN_LENGTH_MAX 12 MINUTES
-
-
-/datum/station_trait/lucky_winner
-	name = "Lucky winner"
-	trait_type = STATION_TRAIT_POSITIVE
-	weight = 1
-	show_in_report = TRUE
-	report_message = "Your station has won the grand prize of the annual station charity event. Free snacks will be delivered to the bar every now and then."
-	trait_processes = TRUE
-	COOLDOWN_DECLARE(party_cooldown)
-
-/datum/station_trait/lucky_winner/on_round_start()
-	. = ..()
-	COOLDOWN_START(src, party_cooldown, rand(PARTY_COOLDOWN_LENGTH_MIN, PARTY_COOLDOWN_LENGTH_MAX))
-
-/datum/station_trait/lucky_winner/process(delta_time)
-	if(!COOLDOWN_FINISHED(src, party_cooldown))
-		return
-
-	COOLDOWN_START(src, party_cooldown, rand(PARTY_COOLDOWN_LENGTH_MIN, PARTY_COOLDOWN_LENGTH_MAX))
-
-	var/area/area_to_spawn_in = pick(GLOB.bar_areas)
-	var/turf/T = pick(area_to_spawn_in.contents)
-
-	var/obj/structure/closet/supplypod/centcompod/toLaunch = new()
-	var/obj/item/pizzabox/pizza_to_spawn = pick(list(/obj/item/pizzabox/margherita, /obj/item/pizzabox/mushroom, /obj/item/pizzabox/meat, /obj/item/pizzabox/vegetable, /obj/item/pizzabox/pineapple))
-	new pizza_to_spawn(toLaunch)
-	for(var/i in 1 to 6)
-		new /obj/item/reagent_containers/food/drinks/beer(toLaunch)
-	new /obj/effect/pod_landingzone(T, toLaunch)
-
 /datum/station_trait/galactic_grant
 	name = "Galactic grant"
 	trait_type = STATION_TRAIT_POSITIVE
@@ -68,42 +35,8 @@
 	report_message = "Prices are low in this system, BUY BUY BUY!"
 	blacklist = list(/datum/station_trait/distant_supply_lines)
 
-
 /datum/station_trait/strong_supply_lines/on_round_start()
 	SSeconomy.pack_price_modifier *= 0.8
-
-/datum/station_trait/scarves
-	name = "Scarves"
-	trait_type = STATION_TRAIT_POSITIVE
-	weight = 5
-	show_in_report = TRUE
-	var/list/scarves
-
-/datum/station_trait/scarves/New()
-	. = ..()
-	report_message = pick(
-		"Nanotrasen is experimenting with seeing if neck warmth improves employee morale.",
-		"After Space Fashion Week, scarves are the hot new accessory.",
-		"Everyone was simultaneously a little bit cold when they packed to go to the station.",
-		"The station is definitely not under attack by neck grappling aliens masquerading as wool. Definitely not.",
-		"You all get free scarves. Don't ask why.",
-		"A shipment of scarves was delivered to the station.",
-	)
-	scarves = typesof(/obj/item/clothing/neck/scarf) + list(
-		/obj/item/clothing/neck/stripedredscarf,
-		/obj/item/clothing/neck/stripedgreenscarf,
-		/obj/item/clothing/neck/stripedbluescarf,
-	)
-
-	RegisterSignal(SSdcs, COMSIG_GLOB_JOB_AFTER_SPAWN, PROC_REF(on_job_after_spawn))
-
-
-/datum/station_trait/scarves/proc/on_job_after_spawn(datum/source, datum/job/job, mob/living/spawned, client/player_client)
-	SIGNAL_HANDLER
-	var/scarf_type = pick(scarves)
-
-	spawned.equip_to_slot_or_del(new scarf_type(spawned), ITEM_SLOT_NECK, initial = FALSE)
-
 
 /datum/station_trait/filled_maint
 	name = "Filled up maintenance"
@@ -135,7 +68,7 @@
 
 	var/department_to_apply_to
 	var/department_name = "department"
-	var/datum/deathrattle_group/deathrattle_group
+	var/datum/deathrattle_group/crew/deathrattle_group
 
 /datum/station_trait/deathrattle_department/New()
 	. = ..()
@@ -144,7 +77,6 @@
 	name = "deathrattled [department_name]"
 	report_message = "All members of [department_name] have received an implant to notify each other if one of them dies. This should help improve job-safety!"
 	RegisterSignal(SSdcs, COMSIG_GLOB_JOB_AFTER_SPAWN, PROC_REF(on_job_after_spawn))
-
 
 /datum/station_trait/deathrattle_department/proc/on_job_after_spawn(datum/source, datum/job/job, mob/living/spawned, client/player_client)
 	SIGNAL_HANDLER
@@ -155,7 +87,6 @@
 	var/obj/item/implant/deathrattle/implant_to_give = new()
 	deathrattle_group.register(implant_to_give)
 	implant_to_give.implant(spawned, spawned, TRUE, TRUE)
-
 
 /datum/station_trait/deathrattle_department/service
 	trait_flags = NONE
@@ -205,8 +136,7 @@
 	show_in_report = TRUE
 	weight = 1
 	report_message = "All members of the station have received an implant to notify each other if one of them dies. This should help improve job-safety!"
-	var/datum/deathrattle_group/deathrattle_group
-
+	var/datum/deathrattle_group/crew/deathrattle_group
 
 /datum/station_trait/deathrattle_all/New()
 	. = ..()
@@ -214,50 +144,9 @@
 	blacklist = subtypesof(/datum/station_trait/deathrattle_department)
 	RegisterSignal(SSdcs, COMSIG_GLOB_JOB_AFTER_SPAWN, PROC_REF(on_job_after_spawn))
 
-
 /datum/station_trait/deathrattle_all/proc/on_job_after_spawn(datum/source, datum/job/job, mob/living/spawned, client/player_client)
 	SIGNAL_HANDLER
 
 	var/obj/item/implant/deathrattle/implant_to_give = new()
 	deathrattle_group.register(implant_to_give)
 	implant_to_give.implant(spawned, spawned, TRUE, TRUE)
-
-
-/datum/station_trait/wallets
-	name = "Wallets!"
-	trait_type = STATION_TRAIT_POSITIVE
-	show_in_report = TRUE
-	weight = 10
-	report_message = "It has become temporarily fashionable to use a wallet, so everyone on the station has been issued one."
-
-/datum/station_trait/wallets/New()
-	. = ..()
-	RegisterSignal(SSdcs, COMSIG_GLOB_JOB_AFTER_SPAWN, PROC_REF(on_job_after_spawn))
-
-/datum/station_trait/wallets/proc/on_job_after_spawn(datum/source, datum/job/job, mob/living/living_mob, mob/M, joined_late)
-	SIGNAL_HANDLER
-
-	var/obj/item/card/id/id_card = living_mob.get_item_by_slot(ITEM_SLOT_ID)
-	if(!istype(id_card))
-		return
-
-	living_mob.temporarilyRemoveItemFromInventory(id_card, force=TRUE)
-
-	// "Doc, what's wrong with me?"
-	var/obj/item/storage/wallet/wallet = new(src)
-	// "You've got a wallet embedded in your chest."
-	wallet.add_fingerprint(living_mob, ignoregloves = TRUE)
-
-	living_mob.equip_to_slot_if_possible(wallet, ITEM_SLOT_ID, initial=TRUE)
-
-	id_card.forceMove(wallet)
-
-	var/holochip_amount = id_card.registered_account.account_balance
-	new /obj/item/holochip(wallet, holochip_amount)
-	id_card.registered_account.adjust_money(-holochip_amount)
-
-	new /obj/effect/spawner/lootdrop/wallet_loot(wallet)
-
-	// Put our filthy fingerprints all over the contents
-	for(var/obj/item/item in wallet)
-		item.add_fingerprint(living_mob, ignoregloves = TRUE)

--- a/code/game/objects/items/implants/implant_deathrattle.dm
+++ b/code/game/objects/items/implants/implant_deathrattle.dm
@@ -1,6 +1,7 @@
 /datum/deathrattle_group
 	var/name
 	var/list/implants = list()
+	var/reveal_death_location = TRUE
 
 /datum/deathrattle_group/New(name)
 	if(name)
@@ -70,8 +71,11 @@
 
 		// Deliberately the same message framing as nanite message + ghost deathrattle
 		var/mob/living/recipient = implant.imp_in
-		to_chat(recipient, "<i>You hear a strange, robotic voice in your head...</i> \"[span_robot("<b>[name]</b> has died at <b>[area]</b>.")]\"")
+		to_chat(recipient, "<i>You hear a strange, robotic voice in your head...</i> \"[span_robot("<b>[name]</b> has died[reveal_death_location  ? "" : " at <b>[area]</b>"].")]\"")
 		recipient.playsound_local(get_turf(recipient), sound, vol = 75, vary = FALSE, pressure_affected = FALSE, use_reverb = FALSE)
+
+/datum/deathrattle_group/crew
+	reveal_death_location = FALSE
 
 /obj/item/implant/deathrattle
 	name = "deathrattle implant"


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the scarf and wallet giving station traits as well as "lucky winner" trait and the light-smashing "blackout" trait. Also nerfs the deathrattle implants the crew get from its respective trait.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

- Scarves and wallets can be obtained in-round by those who want them - these traits usually just lead to a pile of their type discarded in arrivals.
- Blackout is annoying without leading to interesting opportunities, the fact it triggers at shiftstart being the main issue as the majority of antags are not immediately active (it doesn't incentivize this, either).
- Deathrattle is fairer to antags and spookier for the crew if it doesn't reveal the location of the victim.
- Lucky Winner invalidates the chef.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed the scarf and wallet granting station traits, as well as the "blackout" and "lucky winner" station traits.
balance: Nanotrasen deathrattle implants don't reveal the area the victim died in.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
