### PR TITLE
Various mining tweaks: the PKC gives mining exp when you break rocks with it, ports a fix for Legion not giving the crusher achievement, fixes a typo.

### DIFF
--- a/code/datums/achievements/boss_scores.dm
+++ b/code/datums/achievements/boss_scores.dm
@@ -23,7 +23,7 @@
 	desc = "You've killed HOW many?"
 	database_id = BUBBLEGUM_SCORE
 
-/datum/award/score/colussus_score
+/datum/award/score/colossus_score
 	name = "Colossus Killed"
 	desc = "You've killed HOW many?"
 	database_id = COLOSSUS_SCORE

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -198,7 +198,7 @@
 	if(ismineralturf(target_turf))
 		var/turf/closed/mineral/M = target_turf
 		new /obj/effect/temp_visual/kinetic_blast(M)
-		M.gets_drilled(firer)
+		M.gets_drilled(firer, TRUE)
 	..()
 
 //trophies

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -46,7 +46,7 @@
 	gps_name = "Angelic Signal"
 	achievement_type = /datum/award/achievement/boss/colossus_kill
 	crusher_achievement_type = /datum/award/achievement/boss/colossus_crusher
-	score_achievement_type = /datum/award/score/colussus_score
+	score_achievement_type = /datum/award/score/colossus_score
 	crusher_loot = list(/obj/structure/closet/crate/necropolis/colossus/crusher)
 	loot = list(/obj/structure/closet/crate/necropolis/colossus)
 	deathmessage = "disintegrates, leaving a glowing core in its wake."

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -86,10 +86,12 @@
 	if(health > 0)
 		return
 	var/datum/status_effect/crusher_damage/crusher_dmg = has_status_effect(STATUS_EFFECT_CRUSHERDAMAGETRACKING)
+	///Whether we killed the megafauna with primarily crusher damage or not
 	var/crusher_kill = FALSE
-	if(crusher_dmg && crusher_loot && crusher_dmg.total_damage >= maxHealth * 0.6)
-		spawn_crusher_loot()
+	if(crusher_dmg && crusher_dmg.total_damage >= maxHealth * 0.6)
 		crusher_kill = TRUE
+		if(crusher_loot) // spawn crusher loot, if any
+			spawn_crusher_loot()
 	if(true_spawn && !(flags_1 & ADMIN_SPAWNED_1))
 		var/tab = "megafauna_kills"
 		if(crusher_kill)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Breaking rocks with the PKC will now award mining skill exp, same as the PKA.

The achievement for killing Legion with a PKC will trigger as intended thanks to https://github.com/tgstation/tgstation/pull/71246 by [Sealed101](https://github.com/Sealed101).

And the name of the Colossus has been corrected from Colussus in its boss kill score datum.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Resolves issues, brings parity to primary mining tools.

## Changelog
:cl:
qol: Breaking rocks with the PKC gives mining exp.
fix: Legion crusher achievement is now obtainable.
spellcheck: Colussus --> Colossus.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
