### PR TITLE
Disables a space ruin and a whiteship, both of which were causing runtimes.

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -317,7 +317,7 @@
 	dwidth = 11
 	height = 22
 	width = 35
-	shuttlekeys = list("whiteship_meta", "whiteship_pubby", "whiteship_box", "whiteship_cere", "whiteship_kilo", "whiteship_donut", "whiteship_delta", "whiteship_tram")
+	shuttlekeys = list("whiteship_meta", "whiteship_pubby", "whiteship_box", "whiteship_cere", "whiteship_donut", "whiteship_delta", "whiteship_tram")
 
 /obj/docking_port/mobile
 	name = "shuttle"

--- a/config/spaceruinblacklist.txt
+++ b/config/spaceruinblacklist.txt
@@ -12,7 +12,7 @@
 #_maps/RandomRuins/SpaceRuins/asteroid5.dmm
 #_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
 #_maps/RandomRuins/SpaceRuins/bus.dmm
-#_maps/RandomRuins/SpaceRuins/caravanambush.dmm
+_maps/RandomRuins/SpaceRuins/caravanambush.dmm
 #_maps/RandomRuins/SpaceRuins/clericden.dmm
 #_maps/RandomRuins/SpaceRuins/cloning_facility.dmm
 #_maps/RandomRuins/SpaceRuins/clownplanet.dmm


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

See title.
- The caravan ambush ruin and two of the shuttles it spawns have major atmos issues, which I've so far been unable to get to the bottom of.
- The Kilo whiteship cannot dock at the whiteship ruin port.
These can both be reenabled once they're fixed.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: The caravan ambush space ruin and the Kilo whiteship have been temporarily disabled due to causing runtimes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
