### PR TITLE
Turrets all use the same scan range.

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -712,7 +712,6 @@ DEFINE_BITFIELD(turret_flags, list(
 	always_up = TRUE
 	use_power = NO_POWER_USE
 	has_cover = FALSE
-	scan_range = 9
 	req_access = list(ACCESS_SYNDICATE)
 	uses_stored = FALSE
 	mode = TURRET_LETHAL
@@ -765,7 +764,6 @@ DEFINE_BITFIELD(turret_flags, list(
 	lethal_projectile = /obj/projectile/bullet/syndicate_turret
 
 /obj/machinery/porta_turret/syndicate/shuttle
-	scan_range = 9
 	shot_delay = 3
 	stun_projectile = /obj/projectile/bullet/p50/penetrator/shuttle
 	lethal_projectile = /obj/projectile/bullet/p50/penetrator/shuttle
@@ -821,7 +819,6 @@ DEFINE_BITFIELD(turret_flags, list(
 	always_up = TRUE
 	use_power = NO_POWER_USE
 	has_cover = FALSE
-	scan_range = 9
 	stun_projectile = /obj/projectile/beam/laser
 	lethal_projectile = /obj/projectile/beam/laser
 	lethal_projectile_sound = 'sound/weapons/plasma_cutter.ogg'

--- a/code/modules/vehicles/atv.dm
+++ b/code/modules/vehicles/atv.dm
@@ -28,7 +28,6 @@
 
 /obj/machinery/porta_turret/syndicate/vehicle_turret
 	name = "mounted turret"
-	scan_range = 7
 	density = FALSE
 
 /obj/vehicle/ridden/atv/turret/Initialize()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Nerfs the range of Syndie turrets to make them more reactable.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Space movement makes it nearly impossible to avoid getting shot by the turrets of certain ruins.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: All turrets now have a scan range of 7 tiles. (Nerfs Syndie turrets.)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
