### PR TITLE
Ports various nightshift improvements from TG.

### DIFF
--- a/code/controllers/subsystem/nightshift.dm
+++ b/code/controllers/subsystem/nightshift.dm
@@ -44,7 +44,7 @@ SUBSYSTEM_DEF(nightshift)
 	if(nightshift_active != night_time)
 		update_nightshift(night_time, announcing)
 
-/datum/controller/subsystem/nightshift/proc/update_nightshift(active, announce = TRUE, resumed = FALSE)
+/datum/controller/subsystem/nightshift/proc/update_nightshift(active, announce = TRUE, resumed = FALSE, forced = FALSE)
 	if(!resumed)
 		currentrun = GLOB.apcs_list.Copy()
 		nightshift_active = active
@@ -56,6 +56,6 @@ SUBSYSTEM_DEF(nightshift)
 	for(var/obj/machinery/power/apc/APC as anything in currentrun)
 		currentrun -= APC
 		if (APC.area && (APC.area.type in GLOB.the_station_areas))
-			APC.set_nightshift(active)
-		if(MC_TICK_CHECK)
+			APC.set_nightshift(nightshift_active)
+		if(MC_TICK_CHECK && !forced) // subsystem will be in state SS_IDLE if forced by an admin
 			return

--- a/code/controllers/subsystem/security_level.dm
+++ b/code/controllers/subsystem/security_level.dm
@@ -13,5 +13,6 @@ SUBSYSTEM_DEF(security_level)
 /datum/controller/subsystem/security_level/proc/set_level(new_level)
 	SSsecurity_level.current_level = new_level
 	SEND_SIGNAL(src, COMSIG_SECURITY_LEVEL_CHANGED, new_level)
-	SSnightshift.check_nightshift()
+	if(SSnightshift.can_fire && (current_level >= SEC_LEVEL_RED))
+		SSnightshift.next_fire = world.time + 7 SECONDS // Fire nightshift after the security level announcement is complete
 	SSblackbox.record_feedback("tally", "security_level_changes", 1, get_security_level())

--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -183,13 +183,13 @@
 						SSnightshift.can_fire = TRUE
 						SSnightshift.fire()
 					else
-						SSnightshift.update_nightshift(FALSE, TRUE)
+						SSnightshift.update_nightshift(active = FALSE, announce = TRUE, forced = TRUE)
 				if("On")
 					SSnightshift.can_fire = FALSE
-					SSnightshift.update_nightshift(TRUE, TRUE)
+					SSnightshift.update_nightshift(active = TRUE, announce = TRUE, forced = TRUE)
 				if("Off")
 					SSnightshift.can_fire = FALSE
-					SSnightshift.update_nightshift(FALSE, TRUE)
+					SSnightshift.update_nightshift(active = FALSE, announce = TRUE, forced = TRUE)
 		if("moveferry")
 			SSblackbox.record_feedback("nested tally", "admin_secrets_fun_used", 1, list("Send CentCom Ferry"))
 			if(!SSshuttle.toggleShuttle("ferry","ferry_home","ferry_away"))

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -796,7 +796,7 @@
 			to_chat(user, span_warning("Access denied."))
 
 /obj/machinery/power/apc/proc/toggle_nightshift_lights(mob/living/user)
-	if(last_nightshift_switch > world.time - 100) //~10 seconds between each toggle to prevent spamming
+	if(last_nightshift_switch > world.time - 10 SECONDS) //~10 seconds between each toggle to prevent spamming
 		to_chat(usr, span_warning("[src]'s night lighting circuit breaker is still cycling!"))
 		return
 	last_nightshift_switch = world.time
@@ -994,7 +994,7 @@
 			toggle_breaker(usr)
 			. = TRUE
 		if("toggle_nightshift")
-			toggle_nightshift_lights()
+			toggle_nightshift_lights(usr)
 			. = TRUE
 		if("charge")
 			chargemode = !chargemode


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports the following PRs from TG:
https://github.com/tgstation/tgstation/pull/68566 by [Profakos](https://github.com/Profakos).
https://github.com/tgstation/tgstation/pull/74657 by [lessthnthree](https://github.com/lessthnthree).
https://github.com/tgstation/tgstation/pull/79369 by [lessthnthree](https://github.com/lessthnthree).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Nightshift will be less janky.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Nightshift lighting can be forced on and off by admins, as intended.
fix: If you toggle night shift mode on an APC too fast, you'll see the balloon message.
qol: Security level and nightshift announcements no longer stack.
code: Changing security levels will only trigger the nightshift subsystem if lighting changes are required.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
