### PR TITLE
Ports auto-connecting canister ports from Artea.

### DIFF
--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -112,7 +112,7 @@
 	description = "Just somewhere quiet, where I can focus on my work with no interruptions."
 
 /datum/map_template/ruin/space/caravanambush
-	id = "space/caravanambush"
+	id = "caravanambush"
 	suffix = "caravanambush.dmm"
 	name = "Syndicate Ambush"
 	description = "A caravan route used by passing cargo freights has been ambushed by a salvage team manned by the syndicate. \

--- a/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
@@ -16,11 +16,16 @@
 	custom_reconcilation = TRUE
 
 	var/obj/machinery/portable_atmospherics/connected_device
+	/// If TRUE, it will try to connect to a canister on roundstart.
+	var/connect_roundstart = FALSE
 
 /obj/machinery/atmospherics/components/unary/portables_connector/New()
 	..()
 	var/datum/gas_mixture/air_contents = airs[1]
 	air_contents.volume = 0
+	if(!connect_roundstart)
+		return
+	addtimer(CALLBACK(src, PROC_REF(connect_to_canister)), 1 SECONDS)
 
 /obj/machinery/atmospherics/components/unary/portables_connector/Destroy()
 	if(connected_device)
@@ -51,21 +56,48 @@
 		to_chat(user, span_warning("You cannot unwrench [src], detach [connected_device] first!"))
 		return FALSE
 
+/obj/machinery/atmospherics/components/unary/portables_connector/proc/connect_to_canister()
+	connect_roundstart = FALSE
+	var/obj/machinery/portable_atmospherics/canister = locate(/obj/machinery/portable_atmospherics) in loc
+	if(canister)
+		canister.connect(src)
+		return
+	// Crash so CI gets angry
+	CRASH("No connectable found on top of the portables connector at [x], [y], [z]! Fix this.")
+
+/obj/machinery/atmospherics/components/unary/portables_connector/auto_connect
+	connect_roundstart = TRUE
+
 /obj/machinery/atmospherics/components/unary/portables_connector/layer2
 	piping_layer = 2
 	icon_state = "connector_map-2"
+
+/obj/machinery/atmospherics/components/unary/portables_connector/layer2/auto_connect
+	connect_roundstart = TRUE
 
 /obj/machinery/atmospherics/components/unary/portables_connector/layer4
 	piping_layer = 4
 	icon_state = "connector_map-4"
 
+/obj/machinery/atmospherics/components/unary/portables_connector/layer4/auto_connect
+	connect_roundstart = TRUE
+
 /obj/machinery/atmospherics/components/unary/portables_connector/visible
 	hide = FALSE
+
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/auto_connect
+	connect_roundstart = TRUE
 
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2
 	piping_layer = 2
 	icon_state = "connector_map-2"
 
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2/auto_connect
+	connect_roundstart = TRUE
+
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4
 	piping_layer = 4
 	icon_state = "connector_map-4"
+
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4/auto_connect
+	connect_roundstart = TRUE

--- a/config/spaceruinblacklist.txt
+++ b/config/spaceruinblacklist.txt
@@ -27,7 +27,6 @@ _maps/RandomRuins/SpaceRuins/caravanambush.dmm
 #_maps/RandomRuins/SpaceRuins/derelict6.dmm
 #_maps/RandomRuins/SpaceRuins/djstation.dmm
 #_maps/RandomRuins/SpaceRuins/emptyshell.dmm
-#_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
 #_maps/RandomRuins/SpaceRuins/gondolaasteroid.dmm
 #_maps/RandomRuins/SpaceRuins/hilbertshoteltestingsite.dmm
 #_maps/RandomRuins/SpaceRuins/intactemptyship.dmm


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports https://github.com/Artea-Station/Artea-Station-Server/pull/524 by [RimiNosha](https://github.com/RimiNosha), which is a partial port of https://github.com/BeeStation/BeeStation-Hornet/pull/10413 by [Dejaku51](https://github.com/Dejaku51).

Also does a couple of minor space ruin related tweaks, namely:
- Changes the ID of the caravan ambush space ruin to no longer contain a /.
- Removes a removed ruin from the space ruins blacklist, as it's no longer in the game.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Allows mappers to place canisters that are connected to pipenets at roundstart.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds auto-connecting canister ports for mappers.
code: Removes a removed ruin from the space ruins blacklist.
code: The caravan ambush space ruin's ID has been tweaked.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
