### PR TITLE
Disables felinids, adds a "felinid" quirk.

### DIFF
--- a/code/datums/quirks/neutral.dm
+++ b/code/datums/quirks/neutral.dm
@@ -287,3 +287,12 @@
 
 /datum/quirk/item_quirk/colorist/add_unique()
 	give_item_to_holder(/obj/item/dyespray, list(LOCATION_BACKPACK = ITEM_SLOT_BACKPACK, LOCATION_HANDS = ITEM_SLOT_HANDS))
+
+/datum/quirk/item_quirk/felinid
+	name = "Felinid"
+	desc = "You like to signal your allegiance to 'felinid' subculture with a pair of false cat ears (tail included!)."
+	value = 0
+	medical_record_text = "Patient likes to wear a pair of cat ears."
+
+/datum/quirk/item_quirk/felinid/add_unique()
+	give_item_to_holder(/obj/item/clothing/head/kitty, list(LOCATION_HEAD = ITEM_SLOT_HEAD, LOCATION_BACKPACK = ITEM_SLOT_BACKPACK, LOCATION_HANDS = ITEM_SLOT_HANDS))

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -420,7 +420,7 @@ ROUNDSTART_RACES lizard
 ROUNDSTART_RACES moth
 #ROUNDSTART_RACES plasmaman
 #ROUNDSTART_RACES shadow
-ROUNDSTART_RACES felinid
+#ROUNDSTART_RACES felinid
 
 ## Races that are better than humans in some ways, but worse in others
 #ROUNDSTART_RACES jelly


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Disables felinids but adds a "felinid" quirk that allows the taker to spawn with a pair of kitty ears.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I'm not entirely sure felinids fit with the vision I have for the server, and I've umm'd and err'd a lot about it. Recasting them as a subculture, rather than a species, is the best idea I have for them right now.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds a "felinid" quirk that spawns the taker with a pair of wearable cat ears.
del: Felinids have been disabled, once again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
