### PR TITLE
Adds a new Syndicate implant and a new drink, both utilising the effect of the now unselectable "bloodlust" quirk.

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -29,7 +29,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 							list("Clown Fan","Mime Fan"), \
 							list("Bad Touch", "Friendly"), \
 							list("Extrovert", "Introvert"), \
-							list("Bloodlust", "Harm-averse"))
+							list("Bloodlust", "Harm-averse", "Pacifism"))
 	return ..()
 
 /datum/controller/subsystem/processing/quirks/proc/SetupQuirks()

--- a/code/datums/quirks/_quirk.dm
+++ b/code/datums/quirks/_quirk.dm
@@ -17,6 +17,8 @@
 	var/processing_quirk = FALSE
 	/// When making an abstract quirk (in OOP terms), don't forget to set this var to the type path for that abstract quirk.
 	var/abstract_parent_type = /datum/quirk
+	/// Is this quirk available at roundstart?/Will it appear in the prefs menu?
+	var/selectable = TRUE
 
 /datum/quirk/Destroy()
 	if(quirk_holder)

--- a/code/datums/quirks/good.dm
+++ b/code/datums/quirks/good.dm
@@ -215,6 +215,7 @@
 	value = 6
 	gain_text = "<span class='notice'> You feel energized by violence.</span>"
 	lose_text = "<span class='danger'> You no longer feel good about hurting others.</span>"
+	selectable = FALSE
 
 /datum/quirk/bloodlust/add()
 	. = ..()

--- a/code/game/objects/items/implants/implant.dm
+++ b/code/game/objects/items/implants/implant.dm
@@ -8,6 +8,8 @@
 	actions_types = list(/datum/action/item_action/hands_free/activate)
 	///true for implant types that can be activated, false for ones that are "always on" like mindshield implants
 	var/activated = TRUE
+	///true for implants with a passive effect that needs to be added to the mob, e.g. adding traits
+	var/passive = FALSE
 	///the mob that's implanted with this
 	var/mob/living/imp_in = null
 	///implant color, used for selecting either the "b" version or the "r" version of the implant case sprite when the implant is in a case.
@@ -94,6 +96,8 @@
 		for(var/X in actions)
 			var/datum/action/implant_action = X
 			implant_action.Grant(target)
+	if(passive)
+		add_passive(target, user)
 	if(ishuman(target))
 		var/mob/living/carbon/human/target_human = target
 		target_human.sec_hud_set_implants()
@@ -120,6 +124,8 @@
 	for(var/X in actions)
 		var/datum/action/implant_action = X
 		implant_action.Grant(source)
+	if(passive)
+		remove_passive(source)
 	if(ishuman(source))
 		var/mob/living/carbon/human/human_source = source
 		human_source.sec_hud_set_implants()
@@ -131,6 +137,7 @@
 	if(imp_in)
 		removed(imp_in)
 	return ..()
+
 /**
  * Gets implant specifications for the implant pad
  */
@@ -140,3 +147,11 @@
 /obj/item/implant/dropped(mob/user)
 	. = TRUE
 	..()
+
+//override this proc for implant subtypes with passive effects; be sure to set the passive var to true
+/obj/item/implant/proc/add_passive(mob/living/target)
+	return
+
+//and this one
+/obj/item/implant/proc/remove_passive(mob/living/source)
+	return

--- a/code/game/objects/items/implants/implant_bloodlust.dm
+++ b/code/game/objects/items/implants/implant_bloodlust.dm
@@ -1,0 +1,15 @@
+/obj/item/implant/bloodlust
+	name = "bloodlust implant"
+	desc = "Causes the implantee to become energized when engaging in melee combat."
+	icon_state = "reagents"
+	activated = FALSE
+	allow_multiple = FALSE
+
+/obj/item/implant/bloodlust/implant(mob/living/target, mob/user, silent = FALSE, force = FALSE)
+	if(!ishuman(target))
+		to_chat(user, "<span class='warning'>The [src] smartly refuses to enter the non-human organism.</span>")
+		return
+	if(target.has_quirk(/datum/quirk/bloodlust))
+		to_chat(user, "<span class='warning'>The [src] detects \the [target] is already under the influence of an endorphin enhancer and refuses to implant.</span>")
+		return
+	. = ..()

--- a/code/game/objects/items/implants/implant_bloodlust.dm
+++ b/code/game/objects/items/implants/implant_bloodlust.dm
@@ -19,9 +19,18 @@
 	. = ..()
 
 /obj/item/implant/bloodlust/add_passive(mob/living/target)
-	target.add_quirk(/datum/quirk/bloodlust)
-	return TRUE
+	return target.add_quirk(/datum/quirk/bloodlust)
 
 /obj/item/implant/bloodlust/remove_passive(mob/living/source)
-	source.remove_quirk(/datum/quirk/bloodlust)
-	return TRUE
+	return source.remove_quirk(/datum/quirk/bloodlust)
+
+///Implanter that spawns with a bloodlust implant, as well as an appropriate name
+/obj/item/implanter/bloodlust
+	name = "implanter (bloodlust)"
+	imp_type = /obj/item/implant/bloodlust
+
+///Implant case that spawns with a bloodlust implant, as well as an appropriate name and description
+/obj/item/implantcase/bloodlust
+	name = "implant case - 'Bloodlust'"
+	desc = "A glass case containing a bloodlust implant."
+	imp_type = /obj/item/implant/bloodlust

--- a/code/game/objects/items/implants/implant_bloodlust.dm
+++ b/code/game/objects/items/implants/implant_bloodlust.dm
@@ -13,7 +13,7 @@
 	if(target.has_quirk(/datum/quirk/bloodlust))
 		to_chat(user, "<span class='warning'>[src] detects \the [target] is already under the influence of an endorphin enhancer and refuses to implant.</span>")
 		return
-	if(HAS_TRAIT(target, TRAIT_PACIFISM) && target.has_quirk(/datum/quirk/harm_averse))
+	if(HAS_TRAIT(target, TRAIT_PACIFISM) || target.has_quirk(/datum/quirk/harm_averse))
 		to_chat(user, "<span class='warning'>[src] detects factors within \the [target] that would negate its effectiveness and refuses to implant.</span>")
 		return
 	. = ..()

--- a/code/game/objects/items/implants/implant_bloodlust.dm
+++ b/code/game/objects/items/implants/implant_bloodlust.dm
@@ -3,13 +3,25 @@
 	desc = "Causes the implantee to become energized when engaging in melee combat."
 	icon_state = "reagents"
 	activated = FALSE
+	passive = TRUE
 	allow_multiple = FALSE
 
 /obj/item/implant/bloodlust/implant(mob/living/target, mob/user, silent = FALSE, force = FALSE)
 	if(!ishuman(target))
-		to_chat(user, "<span class='warning'>The [src] smartly refuses to enter the non-human organism.</span>")
+		to_chat(user, "<span class='warning'>The [src] smartly refuses to enter the non-humanoid organism.</span>")
 		return
 	if(target.has_quirk(/datum/quirk/bloodlust))
 		to_chat(user, "<span class='warning'>The [src] detects \the [target] is already under the influence of an endorphin enhancer and refuses to implant.</span>")
 		return
+	if(HAS_TRAIT(target, TRAIT_PACIFISM) && target.has_quirk(/datum/quirk/harm_averse))
+		to_chat(user, "<span class='warning'>The [src] detects factors within \the [target] that would negate its effectiveness and refuses to implant.</span>")
+		return
 	. = ..()
+
+/obj/item/implant/bloodlust/add_passive(mob/living/target)
+	target.add_quirk(/datum/quirk/bloodlust)
+	return TRUE
+
+/obj/item/implant/bloodlust/remove_passive(mob/living/source)
+	source.remove_quirk(/datum/quirk/bloodlust)
+	return TRUE

--- a/code/game/objects/items/implants/implant_bloodlust.dm
+++ b/code/game/objects/items/implants/implant_bloodlust.dm
@@ -8,13 +8,13 @@
 
 /obj/item/implant/bloodlust/implant(mob/living/target, mob/user, silent = FALSE, force = FALSE)
 	if(!ishuman(target))
-		to_chat(user, "<span class='warning'>The [src] smartly refuses to enter the non-humanoid organism.</span>")
+		to_chat(user, "<span class='warning'>[src] smartly refuses to enter the non-humanoid organism.</span>")
 		return
 	if(target.has_quirk(/datum/quirk/bloodlust))
-		to_chat(user, "<span class='warning'>The [src] detects \the [target] is already under the influence of an endorphin enhancer and refuses to implant.</span>")
+		to_chat(user, "<span class='warning'>[src] detects \the [target] is already under the influence of an endorphin enhancer and refuses to implant.</span>")
 		return
 	if(HAS_TRAIT(target, TRAIT_PACIFISM) && target.has_quirk(/datum/quirk/harm_averse))
-		to_chat(user, "<span class='warning'>The [src] detects factors within \the [target] that would negate its effectiveness and refuses to implant.</span>")
+		to_chat(user, "<span class='warning'>[src] detects factors within \the [target] that would negate its effectiveness and refuses to implant.</span>")
 		return
 	. = ..()
 

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -424,6 +424,12 @@
 /obj/item/storage/box/syndie_kit/imp_stealth/PopulateContents()
 	new /obj/item/implanter/stealth(src)
 
+/obj/item/storage/box/syndie_kit/imp_bloodlust
+	name = "bloodlust implant box"
+
+/obj/item/storage/box/syndie_kit/imp_bloodlust/PopulateContents()
+	new /obj/item/implanter/bloodlust(src)
+
 /obj/item/storage/box/syndie_kit/imp_radio
 	name = "syndicate radio implant box"
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1081,6 +1081,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		dat += "<center>[GetPositiveQuirkCount()] / [MAX_QUIRKS] max positive quirks<br>\
 		<b>Quirk balance remaining:</b> [GetQuirkBalance()]</center><br>"
 		for(var/V in SSquirks.quirks)
+			if(!V.selectable)
+				continue
 			var/datum/quirk/T = SSquirks.quirks[V]
 			var/quirk_name = initial(T.name)
 			var/has_quirk

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1080,7 +1080,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		dat += "<center><b>Current quirks:</b> [all_quirks.len ? all_quirks.Join(", ") : "None"]</center>"
 		dat += "<center>[GetPositiveQuirkCount()] / [MAX_QUIRKS] max positive quirks<br>\
 		<b>Quirk balance remaining:</b> [GetQuirkBalance()]</center><br>"
-		for(var/V in SSquirks.quirks)
+		for(var/datum/quirk/V in SSquirks.quirks)
 			if(!V.selectable)
 				continue
 			var/datum/quirk/T = SSquirks.quirks[V]

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1080,9 +1080,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		dat += "<center><b>Current quirks:</b> [all_quirks.len ? all_quirks.Join(", ") : "None"]</center>"
 		dat += "<center>[GetPositiveQuirkCount()] / [MAX_QUIRKS] max positive quirks<br>\
 		<b>Quirk balance remaining:</b> [GetQuirkBalance()]</center><br>"
-		for(var/datum/quirk/V in SSquirks.quirks)
-			if(!V.selectable)
-				continue
+		for(var/V in SSquirks.quirks)
 			var/datum/quirk/T = SSquirks.quirks[V]
 			var/quirk_name = initial(T.name)
 			var/has_quirk

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1082,6 +1082,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		<b>Quirk balance remaining:</b> [GetQuirkBalance()]</center><br>"
 		for(var/V in SSquirks.quirks)
 			var/datum/quirk/T = SSquirks.quirks[V]
+			if(!initial(T.selectable))
+				continue
 			var/quirk_name = initial(T.name)
 			var/has_quirk
 			var/quirk_cost = initial(T.value) * -1

--- a/code/modules/food_and_drinks/recipes/drinks_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/drinks_recipes.dm
@@ -621,3 +621,7 @@
 /datum/chemical_reaction/drink/pilk
 	results = list(/datum/reagent/consumable/pilk = 2)
 	required_reagents = list(/datum/reagent/consumable/space_cola = 1, /datum/reagent/consumable/milk = 1)
+
+/datum/chemical_reaction/drink/moloko_plus
+	results = list(/datum/reagent/consumable/milk/moloko_plus = 2)
+	required_reagents = list(/datum/reagent/drug/space_drugs = 1, /datum/reagent/consumable/milk = 1)

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -233,6 +233,24 @@
 		holder.remove_reagent(/datum/reagent/consumable/capsaicin, 1 * delta_time)
 	..()
 
+/datum/reagent/consumable/milk/moloko_plus
+	name = "Moloko Plus"
+	description = "Milk with a drop of synthmesc, perfect before a night of violence."
+	taste_description = "milk with a hint of something extra"
+	glass_name = "glass of moloko plus"
+	glass_desc = "Slooshy, bratty, <i>moloko plus</i> makes a droog bezoomny."
+
+/datum/reagent/consumable/milk/moloko_plus/on_mob_metabolize(mob/living/L)
+	if(ishuman(L))
+		if(!HAS_TRAIT(L, TRAIT_PACIFISM) && !L.has_quirk(/datum/quirk/harm_averse) && !L.has_quirk(/datum/quirk/bloodlust))
+			L.add_quirk(/datum/quirk/bloodlust)
+	. = ..()
+
+/datum/reagent/consumable/milk/moloko_plus/on_mob_end_metabolize(mob/living/L)
+	if(L.has_quirk(/datum/quirk/bloodlust))
+		L.remove_quirk(/datum/quirk/bloodlust)
+	. = ..()
+
 /datum/reagent/consumable/soymilk
 	name = "Soy Milk"
 	description = "An opaque white liquid made from soybeans."

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -244,12 +244,10 @@
 	if(ishuman(L))
 		if(!HAS_TRAIT(L, TRAIT_PACIFISM) && !L.has_quirk(/datum/quirk/harm_averse) && !L.has_quirk(/datum/quirk/bloodlust))
 			L.add_quirk(/datum/quirk/bloodlust)
-	. = ..()
 
 /datum/reagent/consumable/milk/moloko_plus/on_mob_end_metabolize(mob/living/L)
 	if(L.has_quirk(/datum/quirk/bloodlust) && !L.implants.Find(/obj/item/implant/bloodlust))
 		L.remove_quirk(/datum/quirk/bloodlust)
-	. = ..()
 
 /datum/reagent/consumable/soymilk
 	name = "Soy Milk"

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -247,7 +247,7 @@
 	. = ..()
 
 /datum/reagent/consumable/milk/moloko_plus/on_mob_end_metabolize(mob/living/L)
-	if(L.has_quirk(/datum/quirk/bloodlust))
+	if(L.has_quirk(/datum/quirk/bloodlust) && L.implants.Find())
 		L.remove_quirk(/datum/quirk/bloodlust)
 	. = ..()
 

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -246,7 +246,7 @@
 	L.add_quirk(/datum/quirk/bloodlust)
 
 /datum/reagent/consumable/milk/moloko_plus/on_mob_end_metabolize(mob/living/L)
-	if(/obj/item/implant/bloodlust in L.implants)
+	if(locate(/obj/item/implant/bloodlust) in L.implants)
 		return
 	L.remove_quirk(/datum/quirk/bloodlust)
 

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -241,13 +241,14 @@
 	glass_desc = "Slooshy, bratty, <i>moloko plus</i> makes a droog bezoomny."
 
 /datum/reagent/consumable/milk/moloko_plus/on_mob_metabolize(mob/living/L)
-	if(ishuman(L))
-		if(!HAS_TRAIT(L, TRAIT_PACIFISM) && !L.has_quirk(/datum/quirk/harm_averse) && !L.has_quirk(/datum/quirk/bloodlust))
-			L.add_quirk(/datum/quirk/bloodlust)
+	if(!ishuman(L) || HAS_TRAIT(L, TRAIT_PACIFISM) || L.has_quirk(/datum/quirk/harm_averse) || L.has_quirk(/datum/quirk/bloodlust))
+		return
+	L.add_quirk(/datum/quirk/bloodlust)
 
 /datum/reagent/consumable/milk/moloko_plus/on_mob_end_metabolize(mob/living/L)
-	if(L.has_quirk(/datum/quirk/bloodlust) && !L.implants.Find(/obj/item/implant/bloodlust))
-		L.remove_quirk(/datum/quirk/bloodlust)
+	if(L.implants.Find(/obj/item/implant/bloodlust))
+		return
+	L.remove_quirk(/datum/quirk/bloodlust)
 
 /datum/reagent/consumable/soymilk
 	name = "Soy Milk"

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -247,7 +247,7 @@
 	. = ..()
 
 /datum/reagent/consumable/milk/moloko_plus/on_mob_end_metabolize(mob/living/L)
-	if(L.has_quirk(/datum/quirk/bloodlust) && L.implants.Find())
+	if(L.has_quirk(/datum/quirk/bloodlust) && !L.implants.Find(/obj/item/implant/bloodlust))
 		L.remove_quirk(/datum/quirk/bloodlust)
 	. = ..()
 

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -246,7 +246,7 @@
 	L.add_quirk(/datum/quirk/bloodlust)
 
 /datum/reagent/consumable/milk/moloko_plus/on_mob_end_metabolize(mob/living/L)
-	if(L.implants.Find(/obj/item/implant/bloodlust))
+	if(/obj/item/implant/bloodlust in L.implants)
 		return
 	L.remove_quirk(/datum/quirk/bloodlust)
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1595,6 +1595,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	surplus = 0
 	purchasable_from = UPLINK_NUKE_OPS
 
+/datum/uplink_item/implants/bloodlust
+	name = "Bloodlust Implant"
+	desc = "The Donk Co. 'Terrorgrind Endorphin Booster' is a revolutionary, passive-type implant that emboldens the user's stamina by forcing them to take pleasure in combat,\
+			however, it is only effective in those with a pre-existing inclination."
+	item = /obj/item/storage/box/syndie_kit/imp_bloodlust
+	cost = 1
+
 /datum/uplink_item/implants/freedom
 	name = "Freedom Implant"
 	desc = "An implant injected into the body and later activated at the user's will. It will attempt to free the \

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1597,7 +1597,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/implants/bloodlust
 	name = "Bloodlust Implant"
-	desc = "The Donk Co. 'Terrorgrind Endorphin Booster' is a revolutionary, passive-type implant that emboldens the user's stamina by forcing them to take pleasure in combat,\
+	desc = "The Donk Co. 'Terrorgrind Endorphin Booster' is a revolutionary, passive-type implant that emboldens the user's stamina by forcing them to take pleasure in combat, \
 			however, it is only effective in those with a pre-existing inclination."
 	item = /obj/item/storage/box/syndie_kit/imp_bloodlust
 	cost = 1

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1298,6 +1298,7 @@
 #include "code\game\objects\items\grenades\syndieminibomb.dm"
 #include "code\game\objects\items\implants\implant.dm"
 #include "code\game\objects\items\implants\implant_abductor.dm"
+#include "code\game\objects\items\implants\implant_bloodlust.dm"
 #include "code\game\objects\items\implants\implant_chem.dm"
 #include "code\game\objects\items\implants\implant_clown.dm"
 #include "code\game\objects\items\implants\implant_deathrattle.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a drink, "moloko plus", made by combining equal parts milk and space drugs. Consuming it will give you the bloodlust effect, restoring stamina while melee attacking, provided you don't have any conflicting traits (e.g. pacifism).

Adds an implant which costs 1tc and has the same effect, except for an unlimited duration!

Disables the bloodlust quirk and adds support for disabling quirks (making them player unselectable).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bloodlust is not an ideal quirk from a design or balance point of view, however, I didn't want to scrap it entirely so this is a way of retaining its effect in other forms.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds a new drink - Moloko Plus.
add: New Syndicate implant - Bloodlust implant.
code: Support for disabling quirks (making them player unselectable).
balance: The "bloodlust" quirk has been disabled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
