### PR TITLE
Skill levels convert out to achievement scores at roundend. Skill capes are now permanent rewards earned through score.

### DIFF
--- a/code/__DEFINES/achievements.dm
+++ b/code/__DEFINES/achievements.dm
@@ -97,6 +97,18 @@
 #define WENDIGO_SCORE  "Wendigos Killed"
 #define TENDRIL_CLEAR_SCORE  "Tendrils Killed"
 
+// Medal hub IDs for skill experience scores
+#define MINING_SKILL_LEVEL "Mining Skill Level"
+#define GAMING_SKILL_LEVEL "Gaming Skill Level"
+#define HACKING_SKILL_LEVEL "Hacking Skill Level"
+#define CLEANING_SKILL_LEVEL "Cleaning Skill Level"
+
+// Skill level thresholds for experience medals, ideally multiples of 28
+#define MINER_MEDAL_EXP_TO_UNLOCK 280
+#define GAMER_MEDAL_EXP_TO_UNLOCK 196
+#define HACKER_MEDAL_EXP_TO_UNLOCK 140
+#define CLEANER_MEDAL_EXP_TO_UNLOCK 364
+
 // DB ID for hardcore random mode
 #define HARDCORE_RANDOM_SCORE "Hardcore Random Score"
 

--- a/code/__DEFINES/achievements.dm
+++ b/code/__DEFINES/achievements.dm
@@ -36,6 +36,9 @@
 
 //Skill medal hub IDs
 #define MEDAL_LEGENDARY_MINER "Legendary Miner"
+#define MEDAL_LEGENDARY_GAMER "Game Genie"
+#define MEDAL_LEGENDARY_HACKER "1337 H4X0R"
+#define MEDAL_LEGENDARY_CLEANER "No Spill Too Small"
 
 //Mafia medal hub IDs (wins)
 #define MAFIA_MEDAL_ASSISTANT "Assistant"

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -222,7 +222,7 @@
 						score_path = /datum/award/score/skill_level/gamer
 						medal_path = /datum/award/achievement/skill/legendary_gamer
 						medal_ref = GAMER_MEDAL_EXP_TO_UNLOCK
-					if("Hacking")
+					if("Protocol Hijacking")
 						score_path = /datum/award/score/skill_level/hacker
 						medal_path = /datum/award/achievement/skill/legendary_hacker
 						medal_ref = HACKER_MEDAL_EXP_TO_UNLOCK

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -215,19 +215,19 @@
 				var/medal_ref
 				switch(skill.name)
 					if("Mining")
-						score_path = /datum/award/score/skill_level_miner
+						score_path = /datum/award/score/skill_level/miner
 						medal_path = /datum/award/achievement/skill/legendary_miner
 						medal_ref = MINER_MEDAL_EXP_TO_UNLOCK
 					if("Gaming")
-						score_path = /datum/award/score/skill_level_gamer
+						score_path = /datum/award/score/skill_level/gamer
 						medal_path = /datum/award/achievement/skill/legendary_gamer
 						medal_ref = GAMER_MEDAL_EXP_TO_UNLOCK
 					if("Hacking")
-						score_path = /datum/award/score/skill_level_hacker
+						score_path = /datum/award/score/skill_level/hacker
 						medal_path = /datum/award/achievement/skill/legendary_hacker
 						medal_ref = HACKER_MEDAL_EXP_TO_UNLOCK
 					if("Cleaning")
-						score_path = /datum/award/score/skill_level_cleaner
+						score_path = /datum/award/score/skill_level/cleaner
 						medal_path = /datum/award/achievement/skill/legendary_cleaner
 						medal_ref = CLEANER_MEDAL_EXP_TO_UNLOCK
 				M.client?.give_award(score_path, M, score_to_add)

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -231,7 +231,7 @@
 						medal_path = /datum/award/achievement/skill/legendary_cleaner
 						medal_ref = CLEANER_MEDAL_EXP_TO_UNLOCK
 				if(M.client?.give_award(score_path, M, score_to_add))
-					to_chat(M, "<span class='big bold'>Score updated successfully.</span>")
+					to_chat(M, "<span class='greenannounce'>[skill.name] score updated successfully!</span>")
 				if((M.client?.get_award_status(score_path) >= medal_ref) && !M.client?.get_award_status(medal_path))
 					M.client?.give_award(medal_path, M)
 
@@ -257,6 +257,8 @@
 		if(speed_round)
 			C?.give_award(/datum/award/achievement/misc/speed_round, C?.mob)
 		handle_random_hardcore_score(C)
+
+	handle_skill_to_score_conversion()
 
 	var/popcount = gather_roundend_feedback()
 	display_report(popcount)

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -231,7 +231,7 @@
 						medal_path = /datum/award/achievement/skill/legendary_cleaner
 						medal_ref = CLEANER_MEDAL_EXP_TO_UNLOCK
 				if(M.client?.give_award(score_path, M, score_to_add))
-					to_chat(M, "<span class='greenannounce'>[skill.name] score updated successfully!</span>")
+					to_chat(M, "<span class='greenannounce'>[skill.name] score updated successfully! [score_to_add] points have been added!</span>")
 				if((M.client?.get_award_status(score_path) >= medal_ref) && !M.client?.get_award_status(medal_path))
 					M.client?.give_award(medal_path, M)
 

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -208,7 +208,7 @@
 	for(var/mob/M in GLOB.alive_player_list)
 		for(var/V in GLOB.skill_types) //issue lies here
 			var/datum/skill/skill = new V
-			var/level = M.mind?.get_skill_level(skill)
+			var/level = M.mind?.get_skill_level(V)
 			if(level > 0)
 				var/score_to_add = level * ((level * 0.5) + 0.5) //sum the positive integers up to and including the input value
 				var/score_path

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -209,7 +209,7 @@
 		for(var/datum/skill/skill in GLOB.skill_types)
 			var/level = M.mind?.get_skill_level(skill)
 			if(level > 0)
-				var/score_to_add = level * ((level * 0.5) + 0.5)
+				var/score_to_add = level * ((level * 0.5) + 0.5) //sum the positive integers up to and including the input value
 				var/score_path
 				var/medal_path
 				var/medal_ref

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -206,7 +206,7 @@
 	if(!SSachievements.achievements_enabled || !SSskills.initialized)
 		return
 	for(var/mob/M in GLOB.alive_player_list)
-		for(var/V in GLOB.skill_types) //issue lies here
+		for(var/V in GLOB.skill_types)
 			var/datum/skill/skill = new V
 			var/level = M.mind?.get_skill_level(V)
 			if(level > 1)

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -206,7 +206,7 @@
 	if(!SSachievements.achievements_enabled || !SSskills.initialized)
 		return
 	for(var/mob/M in GLOB.alive_player_list)
-		for(var/datum/skill/skill in GLOB.skill_types)
+		for(var/datum/skill/skill in GLOB.skill_types) //issue lies here
 			var/level = M.mind?.get_skill_level(skill)
 			if(level > 0)
 				var/score_to_add = level * ((level * 0.5) + 0.5) //sum the positive integers up to and including the input value

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -205,7 +205,7 @@
 /datum/controller/subsystem/ticker/proc/handle_skill_to_score_conversion()
 	if(!SSachievements.achievements_enabled || !SSskills.initialized)
 		return
-	for(var/mob/living/M in GLOB.player_list)
+	for(var/mob/M in GLOB.alive_player_list)
 		for(var/datum/skill/skill in GLOB.skill_types)
 			var/level = M.mind?.get_skill_level(skill)
 			if(level > 0)

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -230,7 +230,8 @@
 						score_path = /datum/award/score/skill_level/cleaner
 						medal_path = /datum/award/achievement/skill/legendary_cleaner
 						medal_ref = CLEANER_MEDAL_EXP_TO_UNLOCK
-				M.client?.give_award(score_path, M, score_to_add)
+				if(M.client?.give_award(score_path, M, score_to_add))
+					to_chat(M, "<span class='big bold'>Score updated successfully.</span>")
 				if((M.client?.get_award_status(score_path) >= medal_ref) && !M.client?.get_award_status(medal_path))
 					M.client?.give_award(medal_path, M)
 

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -206,7 +206,8 @@
 	if(!SSachievements.achievements_enabled || !SSskills.initialized)
 		return
 	for(var/mob/M in GLOB.alive_player_list)
-		for(var/datum/skill/skill in GLOB.skill_types) //issue lies here
+		for(var/V in GLOB.skill_types) //issue lies here
+			var/datum/skill/skill = new V
 			var/level = M.mind?.get_skill_level(skill)
 			if(level > 0)
 				var/score_to_add = level * ((level * 0.5) + 0.5) //sum the positive integers up to and including the input value

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -209,31 +209,31 @@
 		for(var/V in GLOB.skill_types) //issue lies here
 			var/datum/skill/skill = new V
 			var/level = M.mind?.get_skill_level(V)
-			if(level > 0)
+			if(level > 1)
 				var/score_to_add = level * ((level * 0.5) + 0.5) //sum the positive integers up to and including the input value
 				var/score_path
 				var/medal_path
-				var/medal_ref
+				var/medal_req
 				switch(skill.name)
 					if("Mining")
 						score_path = /datum/award/score/skill_level/miner
 						medal_path = /datum/award/achievement/skill/legendary_miner
-						medal_ref = MINER_MEDAL_EXP_TO_UNLOCK
+						medal_req = MINER_MEDAL_EXP_TO_UNLOCK
 					if("Gaming")
 						score_path = /datum/award/score/skill_level/gamer
 						medal_path = /datum/award/achievement/skill/legendary_gamer
-						medal_ref = GAMER_MEDAL_EXP_TO_UNLOCK
+						medal_req = GAMER_MEDAL_EXP_TO_UNLOCK
 					if("Protocol Hijacking")
 						score_path = /datum/award/score/skill_level/hacker
 						medal_path = /datum/award/achievement/skill/legendary_hacker
-						medal_ref = HACKER_MEDAL_EXP_TO_UNLOCK
+						medal_req = HACKER_MEDAL_EXP_TO_UNLOCK
 					if("Cleaning")
 						score_path = /datum/award/score/skill_level/cleaner
 						medal_path = /datum/award/achievement/skill/legendary_cleaner
-						medal_ref = CLEANER_MEDAL_EXP_TO_UNLOCK
+						medal_req = CLEANER_MEDAL_EXP_TO_UNLOCK
 				if(M.client?.give_award(score_path, M, score_to_add))
 					to_chat(M, "<span class='greenannounce'>[skill.name] score updated successfully! [score_to_add] points have been added!</span>")
-				if((M.client?.get_award_status(score_path) >= medal_ref) && !M.client?.get_award_status(medal_path))
+				if((M.client?.get_award_status(score_path) >= medal_req) && !M.client?.get_award_status(medal_path))
 					M.client?.give_award(medal_path, M)
 
 /datum/controller/subsystem/ticker/proc/declare_completion()

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -232,7 +232,7 @@
 						medal_path = /datum/award/achievement/skill/legendary_cleaner
 						medal_req = CLEANER_MEDAL_EXP_TO_UNLOCK
 				if(M.client?.give_award(score_path, M, score_to_add))
-					to_chat(M, "<span class='greenannounce'>[skill.name] score updated successfully! [score_to_add] points have been added!</span>")
+					to_chat(M, "<span class='nicegreen'>[skill.name] score updated successfully! [score_to_add] points have been added!</span>")
 				if((M.client?.get_award_status(score_path) >= medal_req) && !M.client?.get_award_status(medal_path))
 					M.client?.give_award(medal_path, M)
 

--- a/code/datums/achievements/_achievement_data.dm
+++ b/code/datums/achievements/_achievement_data.dm
@@ -109,7 +109,7 @@
 
 /datum/achievement_data/ui_data(mob/user)
 	var/ret_data = list() // screw standards (qustinnus you must rename src.data ok)
-	ret_data["categories"] = list("Bosses", "Misc", "Mafia", "Scores")
+	ret_data["categories"] = list("Bosses", "Misc", "Skills", "Mafia", "Scores")
 	ret_data["achievements"] = list()
 	ret_data["user_key"] = user.ckey
 

--- a/code/datums/achievements/skill_achievements.dm
+++ b/code/datums/achievements/skill_achievements.dm
@@ -3,8 +3,22 @@
 	icon = "baseskill"
 
 /datum/award/achievement/skill/legendary_miner
-	name = "Legendary miner"
+	name = "Legendary Miner"
 	desc = "No mere rock can stop me!"
 	database_id = MEDAL_LEGENDARY_MINER
 	icon = "mining"
 
+/datum/award/achievement/skill/legendary_gamer
+	name = "Game Genie"
+	desc = "All your prizes are belong to us."
+	database_id = MEDAL_LEGENDARY_GAMER
+
+/datum/award/achievement/skill/legendary_hacker
+	name = "1337 H4X0R"
+	desc = "I'm in."
+	database_id = MEDAL_LEGENDARY_HACKER
+
+/datum/award/achievement/skill/legendary_cleaner
+	name = "No Spill Too Small"
+	desc = "Bring on bigger messes!"
+	database_id = MEDAL_LEGENDARY_CLEANER

--- a/code/datums/achievements/skill_scores.dm
+++ b/code/datums/achievements/skill_scores.dm
@@ -1,0 +1,19 @@
+/datum/award/score/skill_level/miner
+	name = "Mining Skill Level"
+	desc = "Your cumulative mining experience, derived from per-shift growth."
+	database_id = MINING_SKILL_LEVEL
+
+/datum/award/score/skill_level/gamer
+	name = "Gaming Skill Level"
+	desc = "Your cumulative gaming experience, derived from per-shift growth."
+	database_id = GAMING_SKILL_LEVEL
+
+/datum/award/score/skill_level/hacker
+	name = "Hacking Skill Level"
+	desc = "Your cumulative hacking experience, derived from per-shift growth."
+	database_id = HACKING_SKILL_LEVEL
+
+/datum/award/score/skill_level/cleaner
+	name = "Cleaning Skill Level"
+	desc = "Your cumulative cleaning experience, derived from per-shift growth."
+	database_id = CLEANING_SKILL_LEVEL

--- a/code/datums/skills/_skill.dm
+++ b/code/datums/skills/_skill.dm
@@ -6,8 +6,6 @@ GLOBAL_LIST_INIT(skill_types, subtypesof(/datum/skill))
 	var/desc = "the art of doing things"
 	///Dictionary of modifier type - list of modifiers (indexed by level). 7 entries in each list for all 7 skill levels.
 	var/modifiers = list(SKILL_SPEED_MODIFIER = list(1, 1, 1, 1, 1, 1, 1)) //Dictionary of modifier type - list of modifiers (indexed by level). 7 entries in each list for all 7 skill levels.
-	///List Path pointing to the skill cape reward that will appear when a user finishes leveling up a skill
-	var/skill_cape_path
 	///List associating different messages that appear on level up with different levels
 	var/list/levelUpMessages = list()
 	///List associating different messages that appear on level up with different levels
@@ -29,7 +27,7 @@ GLOBAL_LIST_INIT(skill_types, subtypesof(/datum/skill))
 	span_nicegreen("I feel like I've become quite proficient at [name]!"),
 	"<span class='nicegreen'>After lots of practice, I've begun to truly understand the intricacies \
 	and surprising depth behind [name]. I now consider myself a master [title].</span>",
-	span_nicegreen("Through incredible determination and effort, I've reached the peak of my [name] abiltities. I'm finally able to consider myself a legendary [title]!") )
+	span_nicegreen("Through incredible determination and effort, I've reached the peak of my [name] abilities. I'm finally able to consider myself a legendary [title]!") )
 	levelDownMessages = list(span_nicegreen("I have somehow completely lost all understanding of [name]. Please tell an admin if you see this."),
 	span_nicegreen("I'm starting to forget what [name] really even is. I need more practice..."),
 	span_nicegreen("I'm getting a little worse at [name]. I'll need to keep practicing to get better at it..."),
@@ -54,30 +52,3 @@ GLOBAL_LIST_INIT(skill_types, subtypesof(/datum/skill))
  */
 /datum/skill/proc/level_lost(datum/mind/mind, new_level, old_level)
 	to_chat(mind.current, levelDownMessages[old_level]) //old_level will be a value from 1 to 6, so we get appropriate message from the 6-element levelUpMessages list
-
-/**
- * try_skill_reward: Checks to see if a user is eligable for a tangible reward for reaching a certain skill level
- *
- * Currently gives the user a special cloak when they reach a legendary level at any given skill
- * Arguments:
- * * mind - The mind that you'll want to send messages and rewards to
- * * new_level - The current level of the user. Used to check if it meets the requirements for a reward
- */
-/datum/skill/proc/try_skill_reward(datum/mind/mind, new_level)
-	if (new_level != SKILL_LEVEL_LEGENDARY)
-		return
-	if (!ispath(skill_cape_path))
-		to_chat(mind.current, span_nicegreen("My legendary [name] skill is quite impressive, though it seems the Professional [title] Association doesn't have any status symbols to commemorate my abilities with. I should let Centcom know of this travesty, maybe they can do something about it."))
-		return
-	if (LAZYFIND(mind.skills_rewarded, src.type))
-		to_chat(mind.current, span_nicegreen("It seems the Professional [title] Association won't send me another status symbol."))
-		return
-	podspawn(list(
-		"target" = get_turf(mind.current),
-		"path" = /obj/structure/closet/supplypod/mechpod,
-		"style" = STYLE_BLUESPACE,
-		"spawn" = skill_cape_path,
-		"delays" = list(POD_TRANSIT = 150, POD_FALLING = 4, POD_OPENING = 30, POD_LEAVING = 30)
-	))
-	to_chat(mind.current, span_nicegreen("My legendary skill has attracted the attention of the Professional [title] Association. It seems they are sending me a status symbol to commemorate my abilities."))
-	LAZYADD(mind.skills_rewarded, src.type)

--- a/code/datums/skills/cleaning.dm
+++ b/code/datums/skills/cleaning.dm
@@ -3,4 +3,3 @@
 	title =  "Cleaner"
 	desc = "It’s not who I am underneath, but what I mop up that defines me."
 	modifiers = list(SKILL_SPEED_MODIFIER = list(1, 0.9, 0.8, 0.7, 0.6, 0.5, 0.36)) //speed also touches probability in using up a soap's charge
-	skill_cape_path = /obj/item/clothing/neck/cloak/skill_reward/cleaning

--- a/code/datums/skills/gaming.dm
+++ b/code/datums/skills/gaming.dm
@@ -4,7 +4,6 @@
 	desc = "My proficiency as a gamer. This helps me beat bosses with ease, powergame in Orion Trail, and makes me wanna slam some gamer fuel."
 	modifiers = list(SKILL_PROBS_MODIFIER = list(0, 5, 10, 15, 15, 20, 25),
 				SKILL_RANDS_MODIFIER = list(0, 1, 2, 3, 4, 5, 7))
-	skill_cape_path = /obj/item/clothing/neck/cloak/skill_reward/gaming
 
 /datum/skill/gaming/New()
 	. = ..()

--- a/code/datums/skills/implant_hacking.dm
+++ b/code/datums/skills/implant_hacking.dm
@@ -3,7 +3,6 @@
 	title = "Hacker"
 	desc = "My knowledge of cybernetic protocols, and how to make them compatible with eachother"
 	modifiers = list(SKILL_TIME_MODIFIER = list(-2, -1, 0, 1, 2, 4, 8))
-	skill_cape_path = /obj/item/clothing/neck/cloak/skill_reward/hacker
 
 /datum/skill/implant_hacking/New()
 	. = ..()

--- a/code/datums/skills/mining.dm
+++ b/code/datums/skills/mining.dm
@@ -3,4 +3,3 @@
 	title = "Miner"
 	desc = "A dwarf's biggest skill, after drinking."
 	modifiers = list(SKILL_SPEED_MODIFIER = list(1, 0.95, 0.9, 0.85, 0.75, 0.6, 0.5),SKILL_PROBS_MODIFIER=list(10, 15, 20, 25, 30, 35, 40))
-	skill_cape_path = /obj/item/clothing/neck/cloak/skill_reward/mining

--- a/code/game/machinery/computer/arcade/arcade.dm
+++ b/code/game/machinery/computer/arcade/arcade.dm
@@ -83,7 +83,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 
 /obj/machinery/computer/arcade/proc/prizevend(mob/user, prizes = 1)
 	SEND_SIGNAL(src, COMSIG_ARCADE_PRIZEVEND, user, prizes)
-	if(user.mind?.get_skill_level(/datum/skill/gaming) >= SKILL_LEVEL_LEGENDARY && HAS_TRAIT(user, TRAIT_GAMERGOD))
+	if(istype(user.get_item_by_slot(ITEM_SLOT_NECK), /obj/item/clothing/neck/cloak/skill_reward/gaming) && HAS_TRAIT(user, TRAIT_GAMERGOD))
 		visible_message("<span class='notice'>[user] inputs an intense cheat code!",\
 		span_notice("You hear a flurry of buttons being pressed."))
 		say("CODE ACTIVATED: EXTRA PRIZES.")

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -269,7 +269,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 				dat += "<ul>"
 				dat += "<li><a href='byond://?src=[REF(src)];choice=1'>[PDAIMG(notes)]Notekeeper</a></li>"
 				dat += "<li><a href='byond://?src=[REF(src)];choice=2'>[PDAIMG(mail)]Messenger</a></li>"
-				dat += "<li><a href='byond://?src=[REF(src)];choice=6'>[PDAIMG(skills)]Skill Tracker</a></li>"
+				dat += "<li><a href='byond://?src=[REF(src)];choice=6'>[PDAIMG(skills)]Skill Growth Tracker</a></li>"
 
 				if (cartridge)
 					if (cartridge.access & CART_CLOWN)
@@ -379,7 +379,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 				else if(cartridge?.spam_enabled)
 					dat += "<a href='byond://?src=[REF(src)];choice=MessageAll'>Send To All</a>"
 			if(6)
-				dat += "<h4>[PDAIMG(mail)] ExperTrak® Skill Tracker V4.26.2</h4>"
+				dat += "<h4>[PDAIMG(mail)] ExperTrak® Skill Growth Tracker V4.26.2</h4>"
 				dat += "<i>Thank you for choosing ExperTrak® brand software! ExperTrak® inc. is proud to be a Nanotrasen employee expertise and effectiveness department subsidary!</i>"
 				dat += "<br><br>This software is designed to track and monitor your skill development as a Nanotrasen employee. Your job performance across different fields has been quantified and categorized below.<br>"
 				var/datum/mind/targetmind = user.mind
@@ -403,8 +403,6 @@ GLOBAL_LIST_EMPTY(PDAs)
 							dat += "<br>" + num2loadingbar(progress_percent) + "([progress_percent*100])%"
 							dat += "<br>OVERALL DEVELOPMENT PROGRESS:"
 							dat += "<br>" + num2loadingbar(overall_percent) + "([overall_percent*100])%"
-						if (lvl_num >= length(SKILL_EXP_LIST) && !(type in targetmind.skills_rewarded))
-							dat += "<br><a href='byond://?src=[REF(src)];choice=SkillReward;skill=[type]'>Contact the Professional [S.title] Association</a>"
 						dat += "</li></ul>"
 			if(21)
 				if(icon_alert && !istext(icon_alert))
@@ -675,15 +673,6 @@ GLOBAL_LIST_EMPTY(PDAs)
 					if("2") // Eject pAI device
 						usr.put_in_hands(pai)
 						to_chat(usr, span_notice("You remove the pAI from the [name]."))
-
-//SKILL FUNCTIONS===================================
-
-			if("SkillReward")
-				var/type = text2path(href_list["skill"])
-				var/datum/skill/S = GetSkillRef(type)
-				var/datum/mind/mind = U.mind
-				var/new_level = mind.get_skill_level(type)
-				S.try_skill_reward(mind, new_level)
 
 //LINK FUNCTIONS===================================
 

--- a/code/game/objects/items/storage/rewards.dm
+++ b/code/game/objects/items/storage/rewards.dm
@@ -17,3 +17,31 @@
 /obj/item/storage/box/reward/bubblegum_gum/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/storage/box/gum/bubblegum(src)
+
+/obj/item/storage/box/reward/skillcape_miner
+	name = "\improper Legendary Miner's cape reward box"
+	desc = "Awarded for dedication to the acquisition of natural resources."
+
+/obj/item/storage/box/reward/skillcape_miner/PopulateContents()
+	new /obj/item/clothing/neck/cloak/skill_reward/mining(src)
+
+/obj/item/storage/box/reward/skillcape_gamer
+	name = "\improper Legendary Gamer's cape reward box"
+	desc = "Awarded for being the very best, like no-one ever was!"
+
+/obj/item/storage/box/reward/skillcape_gamer/PopulateContents()
+	new /obj/item/clothing/neck/cloak/skill_reward/gaming(src)
+
+/obj/item/storage/box/reward/skillcape_hacker
+	name = "\improper Legendary Hacker's cape reward box"
+	desc = "Awarded for demonstrating exceptional skill in the cracking of cyberware encryption."
+
+/obj/item/storage/box/reward/skillcape_hacker/PopulateContents()
+	new /obj/item/clothing/neck/cloak/skill_reward/hacker(src)
+
+/obj/item/storage/box/reward/skillcape_cleaner
+	name = "\improper Legendary Cleaner's cape reward box"
+	desc = "Awarded for providing outstanding janitorial service."
+
+/obj/item/storage/box/reward/skillcape_cleaner/PopulateContents()
+	new /obj/item/clothing/neck/cloak/skill_reward/cleaning(src)

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -659,7 +659,6 @@
 	if(!(H.mind?.get_skill_level(/datum/skill/mining) >= SKILL_LEVEL_MASTER))
 		return
 	drop_ores()
-	H.client.give_award(/datum/award/achievement/skill/legendary_miner, H)
 	var/flags = NONE
 	var/old_type = type
 	if(defer_change) // TODO: make the defer change var a var for any changeturf flag

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1517,11 +1517,12 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if("job_reward") //job rewards should be accompanied by job restrictions
 					fetch_unlocked_achievements()
 					var/list/selectable_job_rewards = list("None")
-					//uncomment and complete when we have some of these in the game
-					/*for(var/achievement in unlocked_achievements)
+					for(var/achievement in unlocked_achievements)
 						switch(achievement)
-							if()
-								selectable_job_rewards += ""*/
+							if(MEDAL_LEGENDARY_MINER)
+								selectable_job_rewards += "Legendary Miner Cape"
+							if(MEDAL_LEGENDARY_CLEANER)
+								selectable_job_rewards += "Legendary Cleaner Cape"
 					if(selectable_job_rewards.len == 1)
 						to_chat(user, "<span class='warning'>You don't have any achievements that grant a job-specific reward unlocked. Try again after unlocking one.</span>")
 					job_reward_name = input(user, "Choose a job-specific reward (if you spawn as that job, you get this reward):", "Job-Specific Reward") as anything in selectable_job_rewards
@@ -1529,6 +1530,12 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						if("None")
 							job_reward_path = null
 							jobs_reward_is_restricted_to = list()
+						if("Legendary Miner Cape")
+							job_reward_path = /obj/item/storage/box/reward/skillcape_miner
+							jobs_reward_is_restricted_to = list("Shaft Miner")
+						if("Legendary Cleaner Cape")
+							job_reward_path = /obj/item/storage/box/reward/skillcape_cleaner
+							jobs_reward_is_restricted_to += "Janitor"
 
 				if("general_reward") //and general rewards should not
 					fetch_unlocked_achievements()
@@ -1539,6 +1546,10 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 								selectable_general_rewards += "Mini-Meteor"
 							if(MEDAL_FRENCHING)
 								selectable_general_rewards += "Bubblegum Gum - Lifetime Supply"
+							if(MEDAL_LEGENDARY_GAMER)
+								selectable_general_rewards += "Legendary Gamer Cape"
+							if(MEDAL_LEGENDARY_HACKER)
+								selectable_general_rewards += "Legendary Hacker Cape"
 					if(selectable_general_rewards.len == 1)
 						to_chat(user, "<span class='warning'>You don't have any achievements that grant a general reward unlocked. Try again after unlocking one.</span>")
 					general_reward_name = input(user, "Choose a general reward (if don't get a job-specific reward, you get this instead):", "General Reward") as anything in selectable_general_rewards
@@ -1549,6 +1560,10 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 							general_reward_path = /obj/item/storage/box/reward/meteor
 						if("Bubblegum Gum - Lifetime Supply")
 							general_reward_path = /obj/item/storage/box/reward/bubblegum_gum
+						if("Legendary Gamer Cape")
+							general_reward_path = /obj/item/storage/box/reward/skillcape_gamer
+						if("Legendary Hacker Cape")
+							general_reward_path = /obj/item/storage/box/reward/skillcape_hacker
 
 				if("uplink_loc")
 					var/new_loc = input(user, "Choose your character's traitor uplink spawn location:", "Character Preference") as null|anything in GLOB.uplink_spawn_loc_list

--- a/code/modules/clothing/suits/cloaks.dm
+++ b/code/modules/clothing/suits/cloaks.dm
@@ -156,7 +156,7 @@
 		COOLDOWN_START(src, effect_cooldown, effect_cooldown_time)
 
 /obj/item/clothing/neck/cloak/skill_reward
-	var/associated_skill_path = /datum/skill
+	var/associated_medal_path
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE
 
 /obj/item/clothing/neck/cloak/skill_reward/examine(mob/user)
@@ -164,22 +164,25 @@
 	. += span_notice("You notice a powerful aura about this cloak, suggesting that only the truly experienced may wield it.")
 
 /obj/item/clothing/neck/cloak/skill_reward/proc/check_wearable(mob/user)
-	return user.mind?.get_skill_level(associated_skill_path) < SKILL_LEVEL_LEGENDARY
+	var/wearable = FALSE
+	if(user.client?.get_award_status(associated_medal_path))
+		wearable = TRUE
+	return wearable
 
 /obj/item/clothing/neck/cloak/skill_reward/proc/unworthy_unequip(mob/user)
 	to_chat(user, "<span class = 'notice'>You feel completely and utterly unworthy to even touch \the [src].</span>")
 	var/hand_index = user.get_held_index_of_item(src)
-	if (hand_index)
+	if(hand_index)
 		user.dropItemToGround(src, TRUE)
 	return FALSE
 
 /obj/item/clothing/neck/cloak/skill_reward/equipped(mob/user, slot)
-	if (check_wearable(user))
+	if(!check_wearable(user))
 		unworthy_unequip(user)
 	return ..()
 
 /obj/item/clothing/neck/cloak/skill_reward/attack_hand(mob/user)
-	if (check_wearable(user))
+	if(!check_wearable(user))
 		unworthy_unequip(user)
 	return ..()
 
@@ -187,19 +190,25 @@
 	name = "legendary gamer's cloak"
 	desc = "Worn by the most skilled professional gamers on the station, this legendary cloak is only attainable by achieving true gaming enlightenment. This status symbol represents the awesome might of a being of focus, commitment, and sheer fucking will. Something casual gamers will never begin to understand."
 	icon_state = "gamercloak"
-	associated_skill_path = /datum/skill/gaming
+	associated_medal_path = /datum/award/achievement/skill/legendary_gamer
 
 /obj/item/clothing/neck/cloak/skill_reward/cleaning
 	name = "legendary cleaner's cloak"
 	desc = "Worn by the most skilled custodians, this legendary cloak is only attainable by achieving janitorial enlightenment. This status symbol represents a being not only extensively trained in grime combat, but one who is willing to use an entire aresenal of cleaning supplies to its full extent to wipe grime's miserable ass off the face of the station."
 	icon_state = "cleanercloak"
-	associated_skill_path = /datum/skill/cleaning
+	associated_medal_path = /datum/award/achievement/skill/legendary_cleaner
 
 /obj/item/clothing/neck/cloak/skill_reward/mining
 	name = "legendary miner's cloak"
 	desc = "Worn by the most skilled miners, this legendary cloak is only attainable by achieving true mineral enlightenment. This status symbol represents a being who has forgotten more about rocks than most miners will ever know, a being who has moved mountains and filled valleys."
 	icon_state = "minercloak"
-	associated_skill_path = /datum/skill/mining
+	associated_medal_path = /datum/award/achievement/skill/legendary_miner
+
+/obj/item/clothing/neck/cloak/skill_reward/hacker
+	name = "legendary hacker's cloak"
+	desc = "Worn by the most skilled of cybernetic hackers, wearing this proves you were able to conquer protocol, and hack any cybernetic. You are not sure if openly wearing an item of clothing that says 'I'm a master in breaking security protocols' is a good idea."
+	icon_state = "hackercloak"
+	associated_medal_path = /datum/award/achievement/skill/legendary_hacker
 
 /obj/item/clothing/neck/cloak/skill_reward/playing
 	name = "legendary veteran's cloak"
@@ -208,11 +217,5 @@
 
 /obj/item/clothing/neck/cloak/skill_reward/playing/check_wearable(mob/user)
 	return user.client?.get_exp_living(TRUE) >= PLAYTIME_VETERAN
-
-/obj/item/clothing/neck/cloak/skill_reward/hacker
-	name = "legendary hacker's cloak"
-	desc = "Worn by the most skilled of cybernetic hackers, wearing this proves you were able to conquer protocol, and hack any cybernetic. You are not sure if openly wearing an item of clothing that says 'I'm a master in breaking security protocols' is a good idea."
-	icon_state = "hackercloak"
-	associated_skill_path = /datum/skill/implant_hacking
 
 

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -555,7 +555,7 @@
 
 /datum/reagent/consumable/pwr_game/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)
 	. = ..()
-	if(exposed_mob?.mind?.get_skill_level(/datum/skill/gaming) >= SKILL_LEVEL_LEGENDARY && (methods & INGEST) && !HAS_TRAIT(exposed_mob, TRAIT_GAMERGOD))
+	if(istype(exposed_mob?.get_item_by_slot(ITEM_SLOT_NECK), /obj/item/clothing/neck/cloak/skill_reward/gaming) && (methods & INGEST) && !HAS_TRAIT(exposed_mob, TRAIT_GAMERGOD))
 		ADD_TRAIT(exposed_mob, TRAIT_GAMERGOD, "pwr_game")
 		to_chat(exposed_mob, "<span class='nicegreen'>As you imbibe the Pwr Game, your gamer third eye opens... \
 		You feel as though a great secret of the universe has been made known to you...</span>")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -450,6 +450,7 @@
 #include "code\datums\achievements\skill_achievements.dm"
 #include "code\datums\actions\beam_rifle.dm"
 #include "code\datums\ai\_ai_behavior.dm"
+#include "code\datums\achievements\skill_scores.dm"
 #include "code\datums\ai\_ai_controller.dm"
 #include "code\datums\ai\_item_behaviors.dm"
 #include "code\datums\ai\generic_actions.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Skillcapes getting taken away at roundend defeats the point of grinding for them. Making them persistent and obtained over a longer duration rewards dedicated players.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Skill levels are converted into score at roundend, earn enough and receive a cool reward.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
