### PR TITLE
Adds megafauna crusher trophies to the mining vendor.

### DIFF
--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -62,7 +62,14 @@
 		new /datum/data/mining_equipment("KA Range Increase", /obj/item/borg/upgrade/modkit/range, 1000),
 		new /datum/data/mining_equipment("KA Damage Increase", /obj/item/borg/upgrade/modkit/damage, 1000),
 		new /datum/data/mining_equipment("KA Cooldown Decrease", /obj/item/borg/upgrade/modkit/cooldown, 1000),
-		new /datum/data/mining_equipment("KA AoE Damage", /obj/item/borg/upgrade/modkit/aoe/mobs, 2000)
+		new /datum/data/mining_equipment("KA AoE Damage", /obj/item/borg/upgrade/modkit/aoe/mobs, 2000),
+		new /datum/data/mining_equipment("Blaster Tubes", /obj/item/crusher_trophy/blaster_tubes, 1000),
+		new /datum/data/mining_equipment("Demon Claws", /obj/item/crusher_trophy/demon_claws, 2000),
+		new /datum/data/mining_equipment("Eye of a Blood Drunk Hunter", /obj/item/crusher_trophy/miner_eye, 1000),
+		new /datum/data/mining_equipment("Ice Block Talisman", /obj/item/crusher_trophy/ice_block_talisman, 2000),
+		new /datum/data/mining_equipment("Tail Spike", /obj/item/crusher_trophy/tail_spike, 1000),
+		new /datum/data/mining_equipment("Vortex Talisman", /obj/item/crusher_trophy/vortex_talisman, 1000),
+		new /datum/data/mining_equipment("Wendigo Horn", /obj/item/crusher_trophy/wendigo_horn, 1500)
 	)
 
 /datum/data/mining_equipment


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Most megafauna crusher trophies can only be obtained once per round owing to the limited number of times the megafauna spawns. This makes it so crusher users must race, neccessitating reckless play, in order to obtain them. It's not a good dynamic to have discord within the mining team and to incentivise boss rushing. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Megafauna trophies can be purchased from the mining vendor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
