### PR TITLE
Adds two softsuit storage units to each map.

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -1791,9 +1791,8 @@
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
 "ajs" = (
-/obj/structure/table,
-/obj/item/storage/briefcase,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/suit_storage_unit/softsuit,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "ajt" = (
@@ -1845,10 +1844,8 @@
 /area/maintenance/starboard/fore)
 "ajR" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/suit_storage_unit/softsuit,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "ajS" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -24455,6 +24455,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/suit_storage_unit/softsuit,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "bSF" = (
@@ -42536,13 +42537,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
 /obj/item/radio/intercom/directional/north,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/suit_storage_unit/softsuit,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "fwD" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -9336,12 +9336,10 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "bKS" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-06"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/machinery/suit_storage_unit/softsuit,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "bKU" = (
@@ -50721,6 +50719,13 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"qbA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/suit_storage_unit/softsuit,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "qbF" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -54703,6 +54708,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"rwp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-06"
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "rwt" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -83047,7 +83061,7 @@ quc
 aox
 aVs
 bKS
-aWT
+qbA
 aVs
 aVs
 aVs
@@ -84331,7 +84345,7 @@ aaa
 aaa
 aaa
 aRA
-aVu
+rwp
 aWU
 aVs
 aaa

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -53487,6 +53487,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"oRb" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/suit_storage_unit/softsuit,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "oRl" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
@@ -81333,8 +81340,8 @@ bbR
 bbR
 bnp
 baK
-bbR
-bbR
+oRb
+oRb
 aZx
 bcX
 aZx


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Softsuits are now accessible in round.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Two softsuits can be found near arrivals on each station.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
